### PR TITLE
fix: install protoc, fix docker image name, and improve release names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,10 @@ jobs:
             target: aarch64-apple-darwin
             artifact: kubestudio-darwin-aarch64
             name: macOS aarch64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact: kubestudio-windows-x86_64.exe
+            name: Windows x86_64
 
     steps:
       - uses: actions/checkout@v4
@@ -78,6 +82,10 @@ jobs:
       - name: Install protobuf (macOS)
         if: runner.os == 'macOS'
         run: brew install protobuf
+
+      - name: Install protoc (Windows)
+        if: runner.os == 'Windows'
+        run: choco install protoc -y
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -94,7 +102,11 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist
-          cp target/${{ matrix.target }}/release/kubestudio dist/${{ matrix.artifact }}
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            cp target/${{ matrix.target }}/release/kubestudio.exe dist/${{ matrix.artifact }}
+          else
+            cp target/${{ matrix.target }}/release/kubestudio dist/${{ matrix.artifact }}
+          fi
           cd dist
           if command -v sha256sum &> /dev/null; then
             sha256sum ${{ matrix.artifact }} > ${{ matrix.artifact }}.sha256
@@ -125,6 +137,10 @@ jobs:
             target: aarch64-apple-darwin
             artifact: ks-connector-darwin-aarch64
             name: macOS aarch64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact: ks-connector-windows-x86_64
+            name: Windows x86_64
 
     steps:
       - uses: actions/checkout@v4
@@ -138,6 +154,10 @@ jobs:
       - name: Install protobuf (macOS)
         if: runner.os == 'macOS'
         run: brew install protobuf
+
+      - name: Install protoc (Windows)
+        if: runner.os == 'Windows'
+        run: choco install protoc -y
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -154,13 +174,18 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist
-          cp target/${{ matrix.target }}/release/ks-connector dist/
-          cd dist && tar -czvf ${{ matrix.artifact }}.tar.gz ks-connector
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            cp target/${{ matrix.target }}/release/ks-connector.exe dist/
+            cd dist && 7z a ${{ matrix.artifact }}.zip ks-connector.exe
+          else
+            cp target/${{ matrix.target }}/release/ks-connector dist/
+            cd dist && tar -czvf ${{ matrix.artifact }}.tar.gz ks-connector
+          fi
 
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: dist/${{ matrix.artifact }}.tar.gz
+          path: dist/${{ matrix.artifact }}.*
 
   release:
     name: Release
@@ -196,13 +221,15 @@ jobs:
             - **macOS (Apple Silicon)**: `kubestudio-darwin-aarch64`
             - **macOS (Intel)**: `kubestudio-darwin-x86_64`
             - **Linux**: `kubestudio-linux-x86_64`
+            - **Windows**: `kubestudio-windows-x86_64.exe`
 
-            After downloading, make executable: `chmod +x kubestudio-*`
+            After downloading on macOS/Linux, make executable: `chmod +x kubestudio-*`
 
             ### Connector Binary (ks-connector)
             - **macOS (Apple Silicon)**: `ks-connector-darwin-aarch64.tar.gz`
             - **macOS (Intel)**: `ks-connector-darwin-x86_64.tar.gz`
             - **Linux**: `ks-connector-linux-x86_64.tar.gz`
+            - **Windows**: `ks-connector-windows-x86_64.zip`
 
             ### Docker
             ```bash


### PR DESCRIPTION
## Summary

- **Install `protoc` on all build platforms** — `strike48-proto` requires the protobuf compiler. Added `protobuf-compiler` (apt) for Linux, `protobuf` (brew) for macOS, and `protoc` (choco) for Windows across both Desktop and Connector builds.
- **Fix Docker image push permission** — `IMAGE_NAME` was hardcoded to `strike48/kubestudio` but the repo lives under `Strike48-public`. GHCR scopes packages to the repo owner, so pushing to `ghcr.io/strike48/kubestudio` fails with `permission_denied: The requested installation does not exist`. Changed to `${{ github.repository }}` so it resolves to the correct `strike48-public/kubestudio`.
- **Add Windows x86_64 release builds** — Added `windows-latest` matrix entries for both Desktop and Connector jobs. The codebase already has full Windows support (named pipes IPC, cmd.exe terminal launching, USERPROFILE env vars). Packages the desktop binary as `.exe` and the connector as a `.zip` archive.
- **Improve job names** — Replaced raw Rust target triples with human-readable names:
  - `Build x86_64-unknown-linux-gnu` -> `Desktop (Linux x86_64)`
  - `Build x86_64-apple-darwin` -> `Desktop (macOS x86_64)`
  - `Build aarch64-apple-darwin` -> `Desktop (macOS aarch64)`
  - `Connector x86_64-unknown-linux-gnu` -> `Connector (Linux x86_64)`
  - etc.
- **Fix hardcoded URLs in release body** — install script and docker pull URLs now use `github.repository` instead of hardcoded `Strike48` org.

## Per-job fix mapping

| Job | Issue | Fix |
|-----|-------|-----|
| Docker Image | `permission_denied` pushing to wrong GHCR namespace | `IMAGE_NAME: ${{ github.repository }}` |
| Desktop (Linux) | missing protoc | added `protobuf-compiler` to existing apt install |
| Desktop (macOS x2) | missing protoc | added `brew install protobuf` step |
| Desktop (Windows) | **new** | added `windows-latest` matrix entry with `choco install protoc` |
| Connector (Linux) | missing protoc, no deps step at all | added apt install step with `protobuf-compiler` |
| Connector (macOS x2) | missing protoc | added `brew install protobuf` step |
| Connector (Windows) | **new** | added `windows-latest` matrix entry with `choco install protoc` |
| Connector (Linux) canceled | cascading failure from macOS siblings | fixed by protoc install |
| All jobs | unclear names | added `name` matrix field with human-readable labels |

## Test plan

- [ ] Trigger a release workflow run to verify all jobs pass
- [ ] Verify Docker image pushes to `ghcr.io/strike48-public/kubestudio` successfully
- [ ] Verify Windows desktop build produces `kubestudio-windows-x86_64.exe`
- [ ] Verify Windows connector build produces `ks-connector-windows-x86_64.zip`
- [ ] Confirm job names appear as "Desktop (Linux x86_64)" etc. in the Actions UI