### PR TITLE
fix: filter artifact download in release job to exclude docker cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,6 +197,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
+          pattern: k*
 
       - name: Prepare assets
         run: |


### PR DESCRIPTION
## Summary

Fixes the release job failing at the artifact download step after all builds succeed.

- `docker/build-push-action@v6` with `cache-to: type=gha` creates an internal cache artifact (`Strike48-public~kubestudio~*.dockerbuild`) alongside the real build artifacts
- The `download-artifact@v4` step had no pattern filter, so it tried to download all 9 artifacts including the docker cache blob
- The cache artifact is ephemeral and not meant for direct download, causing it to fail after 5 retries and abort the entire release job
- Added `pattern: k*` to scope downloads to only `kubestudio-*` and `ks-connector-*` artifacts

## Test plan

- [ ] Release job downloads all 8 build artifacts without error
- [ ] Docker cache artifact is excluded from download
- [ ] GitHub release is created with all expected assets