### PR TITLE
Fix StrikeHub gateway registration for ks-connector

### DIFF
--- a/crates/ks-ui/src/bin/ks-connector.rs
+++ b/crates/ks-ui/src/bin/ks-connector.rs
@@ -1876,13 +1876,9 @@ async fn main() -> anyhow::Result<()> {
 
     if is_strikehub_mode && std::env::var("STRIKE48_URL").is_err() {
         // StrikeHub mode without gateway URL: serve liveview only.
-        tracing::info!(
-            "StrikeHub mode: serving liveview only (no Matrix URL configured)"
-        );
+        tracing::info!("StrikeHub mode: serving liveview only (no Matrix URL configured)");
     } else if is_strikehub_mode {
-        tracing::info!(
-            "StrikeHub mode: will register with gateway and serve liveview"
-        );
+        tracing::info!("StrikeHub mode: will register with gateway and serve liveview");
     }
 
     let ipc = dioxus_ipc();


### PR DESCRIPTION
## Summary
- Allow gateway registration in StrikeHub mode when `STRIKE48_URL` is set, instead of always skipping to liveview-only mode
- Fix OTT registration URL: use server-provided `matrix_api_url` instead of `STRIKE48_API_URL` (local auth proxy) when running inside StrikeHub, since the proxy doesn't have the `/api/connectors/register-with-ott` endpoint

## Test plan
- [x] Verify ks-connector registers with the gateway correctly in StrikeHub mode
- [x] Verify OTT registration hits the correct URL (server-provided, not local proxy)
- [x] Verify non-StrikeHub mode still works as expected