### PR TITLE
Map Ctrl+[ to Escape across all views

### DIFF
--- a/crates/ks-ui/src/app/mod.rs
+++ b/crates/ks-ui/src/app/mod.rs
@@ -8,6 +8,7 @@ pub use helpers::format_age;
 pub use hotkeys::{get_commands, get_commands_with_tools, get_hotkeys};
 pub use resource_items::*;
 
+use crate::utils::is_escape;
 use crate::components::{
     ActionConfirmModal, ActionTarget, ActionType, ApplyManifest, ApplySource, ChatPanel,
     ClusterOverview, CommandPalette, ContainerDrillDown, Context, CreateResource,
@@ -410,10 +411,11 @@ pub fn App() -> Element {
     let onkeydown = move |e: KeyboardEvent| {
         let is_focused = search_is_focused();
 
-        // Map vim j/k to arrow keys for navigation
+        // Map vim j/k to arrow keys, Ctrl+[ to Escape (VT100)
         let effective_key = match &e.key() {
             Key::Character(c) if c == "j" => Key::ArrowDown,
             Key::Character(c) if c == "k" => Key::ArrowUp,
+            Key::Character(c) if c == "[" && e.modifiers().ctrl() => Key::Escape,
             other => other.clone(),
         };
 
@@ -427,7 +429,7 @@ pub fn App() -> Element {
         }
 
         // Special handling for Escape key when search is focused
-        if e.key() == Key::Escape && is_focused {
+        if effective_key == Key::Escape && is_focused {
             search_is_focused.set(false);
             e.stop_propagation();
             return;
@@ -441,7 +443,7 @@ pub fn App() -> Element {
 
         // Handle namespace selector escape
         if namespace_selector_focused() {
-            if e.key() == Key::Escape {
+            if effective_key == Key::Escape {
                 namespace_selector_focused.set(false);
                 if let Some(app_ref) = app_container_ref.read().clone() {
                     spawn(async move {
@@ -454,7 +456,7 @@ pub fn App() -> Element {
         }
 
         if command_palette_open() {
-            if e.key() == Key::Escape {
+            if effective_key == Key::Escape {
                 command_palette_open.set(false);
                 e.stop_propagation();
             }
@@ -463,7 +465,7 @@ pub fn App() -> Element {
 
         // Handle command mode (k9s-style ":" commands for aliases)
         if command_mode_open() {
-            match e.key() {
+            match effective_key {
                 Key::Escape => {
                     command_mode_open.set(false);
                     command_input.set(String::new());
@@ -3164,55 +3166,56 @@ pub fn App() -> Element {
                                     command_input.set(e.value().clone());
                                 },
                                 onkeydown: move |e: KeyboardEvent| {
-                                    match e.key() {
-                                        Key::Escape => {
-                                            command_mode_open.set(false);
-                                            command_input.set(String::new());
-                                            if let Some(app_ref) = app_container_ref.read().clone() {
-                                                spawn(async move {
-                                                    let _ = app_ref.set_focus(true).await;
-                                                });
-                                            }
-                                            e.stop_propagation();
-                                            e.prevent_default();
+                                    if is_escape(&e) {
+                                        command_mode_open.set(false);
+                                        command_input.set(String::new());
+                                        if let Some(app_ref) = app_container_ref.read().clone() {
+                                            spawn(async move {
+                                                let _ = app_ref.set_focus(true).await;
+                                            });
                                         }
-                                        Key::Enter => {
-                                            let cmd = command_input.read().clone();
-                                            command_mode_open.set(false);
-                                            command_input.set(String::new());
+                                        e.stop_propagation();
+                                        e.prevent_default();
+                                    } else {
+                                        match e.key() {
+                                            Key::Enter => {
+                                                let cmd = command_input.read().clone();
+                                                command_mode_open.set(false);
+                                                command_input.set(String::new());
 
-                                            let resolved = plugin_config.read().resolve_alias(&cmd).cloned();
-                                            let target = resolved.unwrap_or_else(|| cmd.clone());
-                                            let sidebar_items = get_all_sidebar_items_with_crds(&crd_state.read().crds);
+                                                let resolved = plugin_config.read().resolve_alias(&cmd).cloned();
+                                                let target = resolved.unwrap_or_else(|| cmd.clone());
+                                                let sidebar_items = get_all_sidebar_items_with_crds(&crd_state.read().crds);
 
-                                            if let Some(idx) = sidebar_items.iter().position(|k| k == &target) {
-                                                tracing::info!("Command mode: navigating to '{}' (index {})", target, idx);
-                                                previous_view.set(current_view.read().clone());
-                                                current_view.set(target.clone());
-                                                nav.write().reset(ViewState::ResourceList);
-                                                selected_index.set(None);
-                                                selected_resource.set(None);
-                                                sidebar_selected_index.set(Some(idx));
+                                                if let Some(idx) = sidebar_items.iter().position(|k| k == &target) {
+                                                    tracing::info!("Command mode: navigating to '{}' (index {})", target, idx);
+                                                    previous_view.set(current_view.read().clone());
+                                                    current_view.set(target.clone());
+                                                    nav.write().reset(ViewState::ResourceList);
+                                                    selected_index.set(None);
+                                                    selected_resource.set(None);
+                                                    sidebar_selected_index.set(Some(idx));
 
-                                                if let Some(crd_name) = target.strip_prefix("crd:") {
-                                                    let crd = crd_state.read().crds.iter()
-                                                        .find(|c| c.name == crd_name)
-                                                        .cloned();
-                                                    selected_crd.set(crd);
-                                                } else {
-                                                    selected_crd.set(None);
+                                                    if let Some(crd_name) = target.strip_prefix("crd:") {
+                                                        let crd = crd_state.read().crds.iter()
+                                                            .find(|c| c.name == crd_name)
+                                                            .cloned();
+                                                        selected_crd.set(crd);
+                                                    } else {
+                                                        selected_crd.set(None);
+                                                    }
                                                 }
-                                            }
 
-                                            if let Some(app_ref) = app_container_ref.read().clone() {
-                                                spawn(async move {
-                                                    let _ = app_ref.set_focus(true).await;
-                                                });
+                                                if let Some(app_ref) = app_container_ref.read().clone() {
+                                                    spawn(async move {
+                                                        let _ = app_ref.set_focus(true).await;
+                                                    });
+                                                }
+                                                e.stop_propagation();
+                                                e.prevent_default();
                                             }
-                                            e.stop_propagation();
-                                            e.prevent_default();
+                                            _ => {}
                                         }
-                                        _ => {}
                                     }
                                 },
                             }
@@ -3651,7 +3654,7 @@ pub fn App() -> Element {
                         });
                     },
                     onkeydown: move |e: KeyboardEvent| {
-                        if e.key() == Key::Escape {
+                        if is_escape(&e) {
                             help_modal_open.set(false);
                             // Refocus app container so hotkeys work
                             if let Some(app_ref) = app_container_ref.read().clone() {

--- a/crates/ks-ui/src/components/action_confirm_modal.rs
+++ b/crates/ks-ui/src/components/action_confirm_modal.rs
@@ -76,30 +76,33 @@ pub fn ActionConfirmModal(props: ActionConfirmModalProps) -> Element {
     };
 
     let target_for_confirm = target.clone();
-    let onkeydown = move |e: KeyboardEvent| match e.key() {
-        Key::Escape => {
+    let onkeydown = move |e: KeyboardEvent| {
+        if crate::utils::is_escape(&e) {
             props.on_cancel.call(());
             e.stop_propagation();
-        }
-        Key::Enter => {
-            if let Some(true) = *selected_option.read() {
-                props.on_confirm.call(target_for_confirm.clone());
-            } else if let Some(false) = *selected_option.read() {
-                props.on_cancel.call(());
+        } else {
+            match e.key() {
+                Key::Enter => {
+                    if let Some(true) = *selected_option.read() {
+                        props.on_confirm.call(target_for_confirm.clone());
+                    } else if let Some(false) = *selected_option.read() {
+                        props.on_cancel.call(());
+                    }
+                    e.stop_propagation();
+                }
+                Key::ArrowLeft | Key::ArrowRight | Key::Tab => {
+                    let current = *selected_option.read();
+                    match current {
+                        None => selected_option.set(Some(false)),
+                        Some(true) => selected_option.set(Some(false)),
+                        Some(false) => selected_option.set(Some(true)),
+                    }
+                    e.stop_propagation();
+                    e.prevent_default();
+                }
+                _ => {}
             }
-            e.stop_propagation();
         }
-        Key::ArrowLeft | Key::ArrowRight | Key::Tab => {
-            let current = *selected_option.read();
-            match current {
-                None => selected_option.set(Some(false)),
-                Some(true) => selected_option.set(Some(false)),
-                Some(false) => selected_option.set(Some(true)),
-            }
-            e.stop_propagation();
-            e.prevent_default();
-        }
-        _ => {}
     };
 
     let action_type = props.action_type.clone();

--- a/crates/ks-ui/src/components/apply_manifest.rs
+++ b/crates/ks-ui/src/components/apply_manifest.rs
@@ -136,7 +136,7 @@ pub fn ApplyManifest(props: ApplyManifestProps) -> Element {
                             return;
                         }
 
-                        if e.key() == Key::Escape {
+                        if crate::utils::is_escape(&e) {
                             on_close.call(());
                             e.stop_propagation();
                             e.prevent_default();
@@ -148,17 +148,14 @@ pub fn ApplyManifest(props: ApplyManifestProps) -> Element {
                         e.stop_propagation();
                     }
                     ApplyManifestState::Results { .. } | ApplyManifestState::Error(_) => {
-                        match e.key() {
-                            Key::Escape | Key::Enter => {
-                                on_close.call(());
-                                e.stop_propagation();
-                                e.prevent_default();
-                            }
-                            _ => {}
+                        if crate::utils::is_escape(&e) || e.key() == Key::Enter {
+                            on_close.call(());
+                            e.stop_propagation();
+                            e.prevent_default();
                         }
                     }
                     _ => {
-                        if e.key() == Key::Escape {
+                        if crate::utils::is_escape(&e) {
                             on_close.call(());
                             e.stop_propagation();
                             e.prevent_default();

--- a/crates/ks-ui/src/components/create_resource.rs
+++ b/crates/ks-ui/src/components/create_resource.rs
@@ -90,65 +90,65 @@ pub fn CreateResource(props: CreateResourceProps) -> Element {
                 let current_state = state.read().clone();
                 match current_state {
                     CreateState::SelectTemplate => {
-                        match e.key() {
-                            Key::Escape => {
-                                on_close.call(());
-                                e.stop_propagation();
-                                e.prevent_default();
-                            }
-                            Key::ArrowDown => {
-                                keyboard_nav_active.set(true);
-                                let current = *selected_index.read();
-                                if current < TEMPLATES.len() - 1 {
-                                    selected_index.set(current + 1);
+                        if crate::utils::is_escape(&e) {
+                            on_close.call(());
+                            e.stop_propagation();
+                            e.prevent_default();
+                        } else {
+                            match e.key() {
+                                Key::ArrowDown => {
+                                    keyboard_nav_active.set(true);
+                                    let current = *selected_index.read();
+                                    if current < TEMPLATES.len() - 1 {
+                                        selected_index.set(current + 1);
+                                    }
+                                    e.stop_propagation();
+                                    e.prevent_default();
                                 }
-                                e.stop_propagation();
-                                e.prevent_default();
-                            }
-                            Key::Character(ref c) if c == "j" => {
-                                keyboard_nav_active.set(true);
-                                let current = *selected_index.read();
-                                if current < TEMPLATES.len() - 1 {
-                                    selected_index.set(current + 1);
+                                Key::Character(ref c) if c == "j" => {
+                                    keyboard_nav_active.set(true);
+                                    let current = *selected_index.read();
+                                    if current < TEMPLATES.len() - 1 {
+                                        selected_index.set(current + 1);
+                                    }
+                                    e.stop_propagation();
+                                    e.prevent_default();
                                 }
-                                e.stop_propagation();
-                                e.prevent_default();
-                            }
-                            Key::ArrowUp => {
-                                keyboard_nav_active.set(true);
-                                let current = *selected_index.read();
-                                if current > 0 {
-                                    selected_index.set(current - 1);
+                                Key::ArrowUp => {
+                                    keyboard_nav_active.set(true);
+                                    let current = *selected_index.read();
+                                    if current > 0 {
+                                        selected_index.set(current - 1);
+                                    }
+                                    e.stop_propagation();
+                                    e.prevent_default();
                                 }
-                                e.stop_propagation();
-                                e.prevent_default();
-                            }
-                            Key::Character(ref c) if c == "k" => {
-                                keyboard_nav_active.set(true);
-                                let current = *selected_index.read();
-                                if current > 0 {
-                                    selected_index.set(current - 1);
+                                Key::Character(ref c) if c == "k" => {
+                                    keyboard_nav_active.set(true);
+                                    let current = *selected_index.read();
+                                    if current > 0 {
+                                        selected_index.set(current - 1);
+                                    }
+                                    e.stop_propagation();
+                                    e.prevent_default();
                                 }
-                                e.stop_propagation();
-                                e.prevent_default();
-                            }
-                            Key::Enter => {
-                                let idx = *selected_index.read();
-                                if let Some(template) = TEMPLATES.get(idx) {
-                                    // Replace namespace in template if provided
-                                    let yaml = if let Some(ns) = &namespace_for_keydown {
-                                        template.yaml.replace("namespace: default", &format!("namespace: {}", ns))
-                                    } else {
-                                        template.yaml.to_string()
-                                    };
-                                    edited_yaml.set(yaml.clone());
-                                    state.set(CreateState::EditYaml(yaml));
+                                Key::Enter => {
+                                    let idx = *selected_index.read();
+                                    if let Some(template) = TEMPLATES.get(idx) {
+                                        let yaml = if let Some(ns) = &namespace_for_keydown {
+                                            template.yaml.replace("namespace: default", &format!("namespace: {}", ns))
+                                        } else {
+                                            template.yaml.to_string()
+                                        };
+                                        edited_yaml.set(yaml.clone());
+                                        state.set(CreateState::EditYaml(yaml));
+                                    }
+                                    e.stop_propagation();
+                                    e.prevent_default();
                                 }
-                                e.stop_propagation();
-                                e.prevent_default();
-                            }
-                            _ => {
-                                e.stop_propagation();
+                                _ => {
+                                    e.stop_propagation();
+                                }
                             }
                         }
                     }
@@ -180,7 +180,7 @@ pub fn CreateResource(props: CreateResourceProps) -> Element {
                             return;
                         }
 
-                        if e.key() == Key::Escape {
+                        if crate::utils::is_escape(&e) {
                             // Go back to template selection and refocus container
                             state.set(CreateState::SelectTemplate);
                             should_refocus.set(true);
@@ -194,13 +194,10 @@ pub fn CreateResource(props: CreateResourceProps) -> Element {
                         e.stop_propagation();
                     }
                     CreateState::Success(_) | CreateState::Error(_) => {
-                        match e.key() {
-                            Key::Escape | Key::Enter => {
-                                on_close.call(());
-                                e.stop_propagation();
-                                e.prevent_default();
-                            }
-                            _ => {}
+                        if crate::utils::is_escape(&e) || e.key() == Key::Enter {
+                            on_close.call(());
+                            e.stop_propagation();
+                            e.prevent_default();
                         }
                     }
                     _ => {}

--- a/crates/ks-ui/src/components/delete_modal.rs
+++ b/crates/ks-ui/src/components/delete_modal.rs
@@ -40,31 +40,31 @@ pub fn DeleteModal(props: DeleteModalProps) -> Element {
     // Handle keyboard navigation
     let target_for_confirm = target.clone();
     let onkeydown = move |e: KeyboardEvent| {
-        match e.key() {
-            Key::Escape => {
-                props.on_cancel.call(());
-                e.stop_propagation();
-            }
-            Key::Enter => {
-                if let Some(true) = *selected_option.read() {
-                    props.on_confirm.call(target_for_confirm.clone());
-                } else if let Some(false) = *selected_option.read() {
-                    props.on_cancel.call(());
+        if crate::utils::is_escape(&e) {
+            props.on_cancel.call(());
+            e.stop_propagation();
+        } else {
+            match e.key() {
+                Key::Enter => {
+                    if let Some(true) = *selected_option.read() {
+                        props.on_confirm.call(target_for_confirm.clone());
+                    } else if let Some(false) = *selected_option.read() {
+                        props.on_cancel.call(());
+                    }
+                    e.stop_propagation();
                 }
-                e.stop_propagation();
-            }
-            Key::ArrowLeft | Key::ArrowRight | Key::Tab => {
-                // Toggle between options
-                let current = *selected_option.read();
-                match current {
-                    None => selected_option.set(Some(false)), // Start with cancel (safer)
-                    Some(true) => selected_option.set(Some(false)),
-                    Some(false) => selected_option.set(Some(true)),
+                Key::ArrowLeft | Key::ArrowRight | Key::Tab => {
+                    let current = *selected_option.read();
+                    match current {
+                        None => selected_option.set(Some(false)),
+                        Some(true) => selected_option.set(Some(false)),
+                        Some(false) => selected_option.set(Some(true)),
+                    }
+                    e.stop_propagation();
+                    e.prevent_default();
                 }
-                e.stop_propagation();
-                e.prevent_default();
+                _ => {}
             }
-            _ => {}
         }
     };
 

--- a/crates/ks-ui/src/components/exec_viewer.rs
+++ b/crates/ks-ui/src/components/exec_viewer.rs
@@ -446,7 +446,7 @@ pub fn ExecViewer(props: ExecViewerProps) -> Element {
                         },
                         onkeydown: move |e: KeyboardEvent| {
                             // Handle escape to go back
-                            if e.key() == Key::Escape {
+                            if crate::utils::is_escape(&e) {
                                 on_back_key.call(());
                                 e.stop_propagation();
                                 e.prevent_default();

--- a/crates/ks-ui/src/components/log_viewer.rs
+++ b/crates/ks-ui/src/components/log_viewer.rs
@@ -245,56 +245,54 @@ pub fn LogViewer(props: LogViewerProps) -> Element {
                             });
                         },
                         onkeydown: move |e: KeyboardEvent| {
-                            match e.key() {
-                                Key::Character(ref c) if !e.modifiers().ctrl() && !e.modifiers().meta() => {
-                                    match c.as_str() {
-                                        "w" => {
-                                            let new_wrap = !*text_wrap.read();
-                                            text_wrap.set(new_wrap);
-                                            e.stop_propagation();
-                                            e.prevent_default();
-                                        }
-                                        "f" => {
-                                            // Toggle follow mode
-                                            let new_following = !*following.read();
-                                            following.set(new_following);
-                                            // If re-enabling follow, scroll to bottom
-                                            if new_following {
-                                                should_scroll.set(true);
+                            if crate::utils::is_escape(&e) {
+                                on_back_key.call(());
+                                e.stop_propagation();
+                            } else {
+                                match e.key() {
+                                    Key::Character(ref c) if !e.modifiers().ctrl() && !e.modifiers().meta() => {
+                                        match c.as_str() {
+                                            "w" => {
+                                                let new_wrap = !*text_wrap.read();
+                                                text_wrap.set(new_wrap);
+                                                e.stop_propagation();
+                                                e.prevent_default();
                                             }
-                                            e.stop_propagation();
-                                            e.prevent_default();
-                                        }
-                                        "t" => {
-                                            // Toggle timestamps display
-                                            let new_timestamps = !*show_timestamps.read();
-                                            show_timestamps.set(new_timestamps);
-                                            e.stop_propagation();
-                                            e.prevent_default();
-                                        }
-                                        _ => {
-                                            e.stop_propagation();
+                                            "f" => {
+                                                // Toggle follow mode
+                                                let new_following = !*following.read();
+                                                following.set(new_following);
+                                                if new_following {
+                                                    should_scroll.set(true);
+                                                }
+                                                e.stop_propagation();
+                                                e.prevent_default();
+                                            }
+                                            "t" => {
+                                                let new_timestamps = !*show_timestamps.read();
+                                                show_timestamps.set(new_timestamps);
+                                                e.stop_propagation();
+                                                e.prevent_default();
+                                            }
+                                            _ => {
+                                                e.stop_propagation();
+                                            }
                                         }
                                     }
-                                }
-                                Key::Escape => {
-                                    on_back_key.call(());
-                                    e.stop_propagation();
-                                }
-                                Key::ArrowUp | Key::PageUp => {
-                                    // Pause following when scrolling up
-                                    if *following.read() {
-                                        following.set(false);
+                                    Key::ArrowUp | Key::PageUp => {
+                                        if *following.read() {
+                                            following.set(false);
+                                        }
+                                        e.stop_propagation();
                                     }
-                                    e.stop_propagation();
+                                    Key::ArrowDown | Key::PageDown | Key::End => {
+                                        e.stop_propagation();
+                                    }
+                                    Key::ArrowLeft | Key::ArrowRight | Key::Home => {
+                                        e.stop_propagation();
+                                    }
+                                    _ => {}
                                 }
-                                Key::ArrowDown | Key::PageDown | Key::End => {
-                                    e.stop_propagation();
-                                }
-                                Key::ArrowLeft | Key::ArrowRight | Key::Home => {
-                                    e.stop_propagation();
-                                }
-                                _ => {}
                             }
                         },
                         onscroll: move |_| {

--- a/crates/ks-ui/src/components/portforward_modal.rs
+++ b/crates/ks-ui/src/components/portforward_modal.rs
@@ -51,83 +51,80 @@ pub fn PortForwardModal(props: PortForwardModalProps) -> Element {
             onkeydown: {
                 let container_ports = props.container_ports.clone();
                 move |e: KeyboardEvent| {
-                    match e.key() {
-                        Key::Escape => {
-                            on_cancel.call(());
-                            e.stop_propagation();
-                            e.prevent_default();
-                        }
-                        Key::Enter => {
-                            // Submit the form
-                            let local_port_str = local_port_input.read().clone();
-                            match local_port_str.parse::<u16>() {
-                                Ok(local_port) => {
-                                    if local_port == 0 {
-                                        error_message.set(Some("Port must be greater than 0".to_string()));
-                                    } else {
-                                        let remote_port = if container_ports.is_empty() {
-                                            local_port
+                    if crate::utils::is_escape(&e) {
+                        on_cancel.call(());
+                        e.stop_propagation();
+                        e.prevent_default();
+                    } else {
+                        match e.key() {
+                            Key::Enter => {
+                                let local_port_str = local_port_input.read().clone();
+                                match local_port_str.parse::<u16>() {
+                                    Ok(local_port) => {
+                                        if local_port == 0 {
+                                            error_message.set(Some("Port must be greater than 0".to_string()));
                                         } else {
-                                            container_ports.get(*selected_port_index.read()).map(|(p, _, _)| *p).unwrap_or(local_port)
-                                        };
-                                        on_confirm.call((local_port, remote_port));
+                                            let remote_port = if container_ports.is_empty() {
+                                                local_port
+                                            } else {
+                                                container_ports.get(*selected_port_index.read()).map(|(p, _, _)| *p).unwrap_or(local_port)
+                                            };
+                                            on_confirm.call((local_port, remote_port));
+                                        }
                                     }
-                                }
-                                Err(_) => {
-                                    error_message.set(Some("Invalid port number".to_string()));
-                                }
-                            }
-                            e.stop_propagation();
-                            e.prevent_default();
-                        }
-                        Key::ArrowUp => {
-                            let current_focus = *focus_zone.read();
-                            if current_focus == ModalFocus::PortList && port_count > 0 {
-                                let current = *selected_port_index.read();
-                                if current > 0 {
-                                    selected_port_index.set(current - 1);
-                                    if let Some((p, _, _)) = container_ports.get(current - 1) {
-                                        local_port_input.set(p.to_string());
+                                    Err(_) => {
+                                        error_message.set(Some("Invalid port number".to_string()));
                                     }
                                 }
                                 e.stop_propagation();
                                 e.prevent_default();
-                            } else if current_focus == ModalFocus::LocalPort && port_count > 0 {
-                                // Move to port list
-                                focus_zone.set(ModalFocus::PortList);
-                                e.stop_propagation();
-                                e.prevent_default();
                             }
-                        }
-                        Key::ArrowDown => {
-                            let current_focus = *focus_zone.read();
-                            if current_focus == ModalFocus::PortList && port_count > 0 {
-                                let current = *selected_port_index.read();
-                                if current < port_count - 1 {
-                                    selected_port_index.set(current + 1);
-                                    if let Some((p, _, _)) = container_ports.get(current + 1) {
-                                        local_port_input.set(p.to_string());
+                            Key::ArrowUp => {
+                                let current_focus = *focus_zone.read();
+                                if current_focus == ModalFocus::PortList && port_count > 0 {
+                                    let current = *selected_port_index.read();
+                                    if current > 0 {
+                                        selected_port_index.set(current - 1);
+                                        if let Some((p, _, _)) = container_ports.get(current - 1) {
+                                            local_port_input.set(p.to_string());
+                                        }
                                     }
+                                    e.stop_propagation();
+                                    e.prevent_default();
+                                } else if current_focus == ModalFocus::LocalPort && port_count > 0 {
+                                    focus_zone.set(ModalFocus::PortList);
+                                    e.stop_propagation();
+                                    e.prevent_default();
+                                }
+                            }
+                            Key::ArrowDown => {
+                                let current_focus = *focus_zone.read();
+                                if current_focus == ModalFocus::PortList && port_count > 0 {
+                                    let current = *selected_port_index.read();
+                                    if current < port_count - 1 {
+                                        selected_port_index.set(current + 1);
+                                        if let Some((p, _, _)) = container_ports.get(current + 1) {
+                                            local_port_input.set(p.to_string());
+                                        }
+                                    } else {
+                                        focus_zone.set(ModalFocus::LocalPort);
+                                    }
+                                    e.stop_propagation();
+                                    e.prevent_default();
+                                }
+                            }
+                            Key::Tab => {
+                                let current = *focus_zone.read();
+                                if current == ModalFocus::LocalPort && port_count > 0 {
+                                    focus_zone.set(ModalFocus::PortList);
                                 } else {
-                                    // At end of list, move to local port input
                                     focus_zone.set(ModalFocus::LocalPort);
                                 }
                                 e.stop_propagation();
                                 e.prevent_default();
                             }
+                            _ => {}
                         }
-                        Key::Tab => {
-                            // Toggle between port list and local port input
-                            let current = *focus_zone.read();
-                            if current == ModalFocus::LocalPort && port_count > 0 {
-                                focus_zone.set(ModalFocus::PortList);
-                            } else {
-                                focus_zone.set(ModalFocus::LocalPort);
-                            }
-                            e.stop_propagation();
-                            e.prevent_default();
-                        }
-                        _ => {}
                     }
                 }
             },

--- a/crates/ks-ui/src/components/resource_list.rs
+++ b/crates/ks-ui/src/components/resource_list.rs
@@ -187,24 +187,25 @@ pub fn ResourceList(mut props: ResourceListProps) -> Element {
                                 return;
                             }
 
-                            match e.key() {
-                                Key::Escape => {
-                                    search.set(String::new());
-                                    let _ = document::eval("document.querySelector('.search-input').value = ''");
-                                    props.search_focused.set(false);
-                                    update_selection(None);
+                            if crate::utils::is_escape(&e) {
+                                search.set(String::new());
+                                let _ = document::eval("document.querySelector('.search-input').value = ''");
+                                props.search_focused.set(false);
+                                update_selection(None);
 
-                                    // Refocus the app container so hotkeys continue to work
-                                    if let Some(app_container_signal) = &props.app_container_ref
-                                        && let Some(app_ref) = app_container_signal.read().clone() {
-                                        spawn(async move {
-                                            let _ = app_ref.set_focus(true).await;
-                                        });
-                                    }
-
-                                    e.prevent_default();
-                                    e.stop_propagation();
+                                // Refocus the app container so hotkeys continue to work
+                                if let Some(app_container_signal) = &props.app_container_ref
+                                    && let Some(app_ref) = app_container_signal.read().clone() {
+                                    spawn(async move {
+                                        let _ = app_ref.set_focus(true).await;
+                                    });
                                 }
+
+                                e.prevent_default();
+                                e.stop_propagation();
+                                return;
+                            }
+                            match e.key() {
                                 Key::Enter => {
                                     // Apply filter and blur - don't select resource
                                     props.search_focused.set(false);

--- a/crates/ks-ui/src/components/sidebar.rs
+++ b/crates/ks-ui/src/components/sidebar.rs
@@ -556,6 +556,7 @@ pub fn Sidebar(props: SidebarProps) -> Element {
                                     let key = match &e.key() {
                                         Key::Character(c) if c == "j" => Key::ArrowDown,
                                         Key::Character(c) if c == "k" => Key::ArrowUp,
+                                        Key::Character(c) if c == "[" && e.modifiers().ctrl() => Key::Escape,
                                         other => other.clone(),
                                     };
 

--- a/crates/ks-ui/src/components/yaml_viewer/mod.rs
+++ b/crates/ks-ui/src/components/yaml_viewer/mod.rs
@@ -278,138 +278,134 @@ pub fn YamlViewer(props: YamlViewerProps) -> Element {
                         return;
                     }
 
-                    match e.key() {
-                        Key::Character(ref c) if !e.modifiers().ctrl() && !e.modifiers().meta() => {
-                            // Skip most shortcuts in edit mode (let textarea handle them)
-                            if *edit_mode.read() {
-                                e.stop_propagation();
-                                return;
-                            }
-                            match c.as_str() {
-                                "e" => {
-                                    // Enter edit mode - switch to YAML view
-                                    if props.read_only {
-                                        tracing::warn!("Edit disabled in read-only mode (KUBESTUDIO_MODE=read)");
-                                    } else if !*edit_mode.read() {
-                                        view_mode.set("yaml".to_string());
-                                        // Get clean YAML without managed fields for editing
-                                        let yaml_for_edit = strip_managed_fields(&content_full.read());
-                                        edited_content.set(yaml_for_edit.clone());
-                                        content.set(yaml_for_edit);
-                                        edit_mode.set(true);
-                                        apply_state.set(ApplyState::Idle);
+                    if crate::utils::is_escape(&e) {
+                        if *edit_mode.read() {
+                            // Cancel edit mode - stay in YAML view
+                            edit_mode.set(false);
+                            apply_state.set(ApplyState::Idle);
+                            // Keep YAML view, restore content without managed fields
+                            view_mode.set("yaml".to_string());
+                            let stripped = strip_managed_fields(&content_full.read());
+                            content.set(stripped);
+                            // Trigger refocus on content
+                            should_refocus_content.set(true);
+                        } else if matches!(*apply_state.read(), ApplyState::Confirming) {
+                            // Cancel confirmation - go back to edit mode
+                            apply_state.set(ApplyState::Idle);
+                        } else {
+                            on_back_key.call(());
+                        }
+                        e.stop_propagation();
+                    } else {
+                        match e.key() {
+                            Key::Character(ref c) if !e.modifiers().ctrl() && !e.modifiers().meta() => {
+                                if *edit_mode.read() {
+                                    e.stop_propagation();
+                                    return;
+                                }
+                                match c.as_str() {
+                                    "e" => {
+                                        if props.read_only {
+                                            tracing::warn!("Edit disabled in read-only mode (KUBESTUDIO_MODE=read)");
+                                        } else if !*edit_mode.read() {
+                                            view_mode.set("yaml".to_string());
+                                            let yaml_for_edit = strip_managed_fields(&content_full.read());
+                                            edited_content.set(yaml_for_edit.clone());
+                                            content.set(yaml_for_edit);
+                                            edit_mode.set(true);
+                                            apply_state.set(ApplyState::Idle);
+                                        }
+                                        e.stop_propagation();
+                                        e.prevent_default();
                                     }
-                                    e.stop_propagation();
-                                    e.prevent_default();
-                                }
-                                "w" => {
-                                    let new_wrap = !*text_wrap.read();
-                                    text_wrap.set(new_wrap);
-                                    e.stop_propagation();
-                                    e.prevent_default();
-                                }
-                                "c" => {
-                                    #[cfg(feature = "desktop")]
-                                    {
-                                        let current_content = content.read().clone();
-                                        if !current_content.is_empty() {
-                                            spawn(async move {
-                                                match arboard::Clipboard::new() {
-                                                    Ok(mut clipboard) => {
-                                                        if clipboard.set_text(&current_content).is_ok() {
-                                                            copied.set(true);
-                                                            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-                                                            copied.set(false);
+                                    "w" => {
+                                        let new_wrap = !*text_wrap.read();
+                                        text_wrap.set(new_wrap);
+                                        e.stop_propagation();
+                                        e.prevent_default();
+                                    }
+                                    "c" => {
+                                        #[cfg(feature = "desktop")]
+                                        {
+                                            let current_content = content.read().clone();
+                                            if !current_content.is_empty() {
+                                                spawn(async move {
+                                                    match arboard::Clipboard::new() {
+                                                        Ok(mut clipboard) => {
+                                                            if clipboard.set_text(&current_content).is_ok() {
+                                                                copied.set(true);
+                                                                tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                                                                copied.set(false);
+                                                            }
+                                                        }
+                                                        Err(e) => {
+                                                            tracing::error!("Failed to access clipboard: {}", e);
                                                         }
                                                     }
-                                                    Err(e) => {
-                                                        tracing::error!("Failed to access clipboard: {}", e);
-                                                    }
-                                                }
-                                            });
+                                                });
+                                            }
                                         }
+                                        #[cfg(not(feature = "desktop"))]
+                                        {
+                                            tracing::debug!("Clipboard copy not available in web mode");
+                                        }
+                                        e.stop_propagation();
+                                        e.prevent_default();
                                     }
-                                    #[cfg(not(feature = "desktop"))]
-                                    {
-                                        // Clipboard not available in web/fullstack mode
-                                        tracing::debug!("Clipboard copy not available in web mode");
+                                    "m" => {
+                                        let show = !show_managed_fields();
+                                        show_managed_fields.set(show);
+                                        if view_mode.read().as_str() == "yaml" {
+                                            if show {
+                                                content.set(content_full.read().clone());
+                                            } else {
+                                                let stripped = strip_managed_fields(&content_full.read());
+                                                content.set(stripped);
+                                            }
+                                        }
+                                        e.stop_propagation();
+                                        e.prevent_default();
                                     }
-                                    e.stop_propagation();
-                                    e.prevent_default();
-                                }
-                                "m" => {
-                                    let show = !show_managed_fields();
-                                    show_managed_fields.set(show);
-                                    if view_mode.read().as_str() == "yaml" {
-                                        if show {
-                                            content.set(content_full.read().clone());
+                                    "h" => {
+                                        let current_mode = view_mode.read().clone();
+                                        if current_mode == "yaml" {
+                                            view_mode.set("describe".to_string());
+                                            let full_yaml = content_full.read().clone();
+                                            let describe_text = yaml_to_describe_format(&full_yaml);
+                                            content.set(describe_text);
                                         } else {
-                                            let stripped = strip_managed_fields(&content_full.read());
-                                            content.set(stripped);
+                                            view_mode.set("yaml".to_string());
+                                            if show_managed_fields() {
+                                                content.set(content_full.read().clone());
+                                            } else {
+                                                let stripped = strip_managed_fields(&content_full.read());
+                                                content.set(stripped);
+                                            }
                                         }
+                                        e.stop_propagation();
+                                        e.prevent_default();
                                     }
-                                    e.stop_propagation();
-                                    e.prevent_default();
-                                }
-                                "h" => {
-                                    let current_mode = view_mode.read().clone();
-                                    if current_mode == "yaml" {
-                                        view_mode.set("describe".to_string());
-                                        let full_yaml = content_full.read().clone();
-                                        let describe_text = yaml_to_describe_format(&full_yaml);
-                                        content.set(describe_text);
-                                    } else {
-                                        view_mode.set("yaml".to_string());
-                                        if show_managed_fields() {
-                                            content.set(content_full.read().clone());
-                                        } else {
-                                            let stripped = strip_managed_fields(&content_full.read());
-                                            content.set(stripped);
+                                    "r" => {
+                                        if is_secret {
+                                            let new_revealed = !*secrets_revealed.read();
+                                            secrets_revealed.set(new_revealed);
                                         }
+                                        e.stop_propagation();
+                                        e.prevent_default();
                                     }
-                                    e.stop_propagation();
-                                    e.prevent_default();
-                                }
-                                "r" => {
-                                    // Toggle secret value reveal (only for Secrets)
-                                    if is_secret {
-                                        let new_revealed = !*secrets_revealed.read();
-                                        secrets_revealed.set(new_revealed);
+                                    _ => {
+                                        e.stop_propagation();
                                     }
-                                    e.stop_propagation();
-                                    e.prevent_default();
-                                }
-                                _ => {
-                                    e.stop_propagation();
                                 }
                             }
-                        }
-                        Key::Escape => {
-                            if *edit_mode.read() {
-                                // Cancel edit mode - stay in YAML view
-                                edit_mode.set(false);
-                                apply_state.set(ApplyState::Idle);
-                                // Keep YAML view, restore content without managed fields
-                                view_mode.set("yaml".to_string());
-                                let stripped = strip_managed_fields(&content_full.read());
-                                content.set(stripped);
-                                // Trigger refocus on content
-                                should_refocus_content.set(true);
-                            } else if matches!(*apply_state.read(), ApplyState::Confirming) {
-                                // Cancel confirmation - go back to edit mode
-                                apply_state.set(ApplyState::Idle);
-                            } else {
-                                on_back_key.call(());
+                            Key::ArrowLeft | Key::ArrowRight => {
+                                e.stop_propagation();
                             }
-                            e.stop_propagation();
+                            Key::ArrowDown | Key::ArrowUp | Key::PageDown | Key::PageUp | Key::Home | Key::End => {
+                                e.stop_propagation();
+                            }
+                            _ => {}
                         }
-                        Key::ArrowLeft | Key::ArrowRight => {
-                            e.stop_propagation();
-                        }
-                        Key::ArrowDown | Key::ArrowUp | Key::PageDown | Key::PageUp | Key::Home | Key::End => {
-                            e.stop_propagation();
-                        }
-                        _ => {}
                     }
                 },
                 if loading() {
@@ -492,20 +488,19 @@ pub fn YamlViewer(props: YamlViewerProps) -> Element {
                         });
                     },
                     onkeydown: move |e: KeyboardEvent| {
-                        match e.key() {
-                            Key::Escape => {
-                                apply_state.set(ApplyState::Idle);
-                                e.stop_propagation();
-                                e.prevent_default();
-                            }
-                            Key::Tab | Key::ArrowLeft | Key::ArrowRight => {
-                                // Toggle selection
-                                let current = *modal_selected.read();
-                                modal_selected.set(if current == 0 { 1 } else { 0 });
-                                e.stop_propagation();
-                                e.prevent_default();
-                            }
-                            Key::Enter => {
+                        if crate::utils::is_escape(&e) {
+                            apply_state.set(ApplyState::Idle);
+                            e.stop_propagation();
+                            e.prevent_default();
+                        } else {
+                            match e.key() {
+                                Key::Tab | Key::ArrowLeft | Key::ArrowRight => {
+                                    let current = *modal_selected.read();
+                                    modal_selected.set(if current == 0 { 1 } else { 0 });
+                                    e.stop_propagation();
+                                    e.prevent_default();
+                                }
+                                Key::Enter => {
                                 let selected = *modal_selected.read();
                                 if selected == 0 {
                                     // Cancel
@@ -542,9 +537,10 @@ pub fn YamlViewer(props: YamlViewerProps) -> Element {
                                 e.stop_propagation();
                                 e.prevent_default();
                             }
-                            _ => {
-                                e.stop_propagation();
-                                e.prevent_default();
+                                _ => {
+                                    e.stop_propagation();
+                                    e.prevent_default();
+                                }
                             }
                         }
                     },

--- a/crates/ks-ui/src/utils/mod.rs
+++ b/crates/ks-ui/src/utils/mod.rs
@@ -1,2 +1,8 @@
-// Utility functions for ks-ui
-// (Currently empty - terminal utilities have been replaced by embedded components)
+use dioxus::prelude::*;
+
+/// Returns true if the keyboard event represents an Escape action.
+/// Matches both the Escape key and Ctrl+[ (VT100 escape sequence).
+pub fn is_escape(e: &KeyboardEvent) -> bool {
+    e.key() == Key::Escape
+        || (e.key() == Key::Character("[".into()) && e.modifiers().ctrl())
+}


### PR DESCRIPTION
## Summary
- Add `is_escape()` utility that matches both Escape and Ctrl+[ (VT100 escape sequence)
- Update all keyboard handlers across every view and modal to recognize Ctrl+[ as Escape
- Affected components: app, sidebar, exec viewer, log viewer, yaml viewer, resource list, delete/portforward/action confirm/apply modals, create resource

## Test plan
- [ ] Verify Ctrl+[ dismisses modals (delete, port-forward, action confirm, help)
- [ ] Verify Ctrl+[ navigates back from yaml/log/exec viewers
- [ ] Verify Ctrl+[ closes command palette and command mode
- [ ] Verify Ctrl+[ clears search in resource list
- [ ] Verify Ctrl+[ closes namespace selector in sidebar
- [ ] Verify regular Escape key still works everywhere