### PR TITLE
Fix connector registration failure when no kubeconfig context is set

### DIFF
--- a/crates/ks-ui/src/bin/ks-connector.rs
+++ b/crates/ks-ui/src/bin/ks-connector.rs
@@ -1970,7 +1970,7 @@ async fn main() -> anyhow::Result<()> {
     // make the instance_id unique per cluster so Matrix doesn't round-robin
     // between connectors targeting different clusters.
     let default_cluster_name: Option<String> = match auth::load_kubeconfig(None).await {
-        Ok(kc) => auth::current_context(&kc),
+        Ok(kc) => auth::current_context(&kc).filter(|s| !s.is_empty()),
         Err(_) => None,
     };
 


### PR DESCRIPTION
## Summary

## Examples of Prospector Studio sidebar view with KubeStudio connected
1. kube context not set; `CONNECTOR_NAME` not set <img width="2032" height="1162" alt="Screenshot 2026-03-17 at 12 28 43 PM" src="https://github.com/user-attachments/assets/ff1f1cb6-ed8a-4667-aaf4-68a055191737" />
2. kube context not set; `CONNECTOR_NAME` is set <img width="2032" height="1162" alt="Screenshot 2026-03-17 at 12 28 03 PM" src="https://github.com/user-attachments/assets/88ec3dce-566b-4f82-b026-fabd7f000e8f" />
3. kube context is set; `CONNECTOR_NAME` not set <img width="2032" height="1162" alt="Screenshot 2026-03-17 at 12 25 25 PM" src="https://github.com/user-attachments/assets/7efb3ce6-0112-4d10-a295-ae850668c532" />
4. kube context is set; `CONNECTOR_NAME` is set <img width="2032" height="1162" alt="Screenshot 2026-03-17 at 12 27 20 PM" src="https://github.com/user-attachments/assets/e01b35fd-158f-4cdb-a8a7-9e1fb088f496" />

## Detail
- Fix connector registration crash when no kubeconfig current-context is set
- `auth::current_context()` returns `Some("")` (empty string) instead of `None` when the kubeconfig file exists but has no current-context — this was passed directly as the app manifest `name`, causing the server to reject registration with "App manifest missing required fields: name"
- Added `.filter(|s| !s.is_empty())` so empty strings are normalized to `None`, allowing the `"KubeStudio"` fallback name to be used

## Test plan

- [ ] Unset kubeconfig context (`kubectl config unset current-context`) and run the connector — should register successfully with name `"KubeStudio"`
- [ ] Set a kubeconfig context (`kubectl config use-context <name>`) and run the connector — should register with the cluster name as before

closes https://github.com/Strike48-public/kubestudio/issues/30