### PR TITLE
feat: replace custom auth with SDK OttProvider

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install cargo-audit
         run: cargo install cargo-audit
       - name: Run cargo audit
-        run: cargo audit --ignore RUSTSEC-2024-0370
+        run: cargo audit --ignore RUSTSEC-2024-0370 --ignore RUSTSEC-2026-0049
 
   cargo-deny:
     name: License & Supply Chain

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install cargo-audit
         run: cargo install cargo-audit
       - name: Run cargo audit
-        run: cargo audit --ignore RUSTSEC-2024-0370 --ignore RUSTSEC-2026-0049
+        run: cargo audit --ignore RUSTSEC-2024-0370
 
   cargo-deny:
     name: License & Supply Chain

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install cargo-audit
         run: cargo install cargo-audit
       - name: Run cargo audit
-        run: cargo audit --ignore RUSTSEC-2024-0370 --ignore RUSTSEC-2023-0071
+        run: cargo audit --ignore RUSTSEC-2024-0370
 
   cargo-deny:
     name: License & Supply Chain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2971,7 +2971,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3402,7 +3402,6 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "hyper-util",
- "jsonwebtoken",
  "k8s-openapi",
  "ks-core",
  "ks-kube",
@@ -3411,11 +3410,9 @@ dependencies = [
  "kube",
  "lucide-dioxus",
  "pulldown-cmark",
- "rand 0.8.5",
  "regex",
  "reqwest 0.12.28",
  "rfd 0.15.4",
- "rsa",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3428,7 +3425,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "urlencoding",
- "uuid",
 ]
 
 [[package]]
@@ -5519,7 +5515,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -5612,9 +5608,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -6212,9 +6208,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strike48-connector"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fa487c6c3aaef9695e4a8a629113a54da75cfa035d2c82f507bf9fb4379f03"
+checksum = "01bb7c6a409699ea7606cb59fca48ee685ad4e753382d5b75cec8afd8be7c420"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6260,9 +6256,9 @@ dependencies = [
 
 [[package]]
 name = "strike48-proto"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6140951637676167e06614785b12db2090c7d1e97c4520800f23504764d6c3"
+checksum = "420fb873cd05b44b6a4782deee4aa4b8197d2fc4e5a1d2b0254e7577a0a435ac"
 dependencies = [
  "prost",
  "prost-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,31 +327,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "axum"
-version = "0.6.20"
+name = "aws-lc-rs"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "itoa 1.0.17",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 0.1.2",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
 ]
 
 [[package]]
@@ -361,15 +356,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core 0.4.5",
+ "axum-core",
  "axum-macros",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "itoa 1.0.17",
  "matchit",
@@ -384,30 +379,13 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.24.0",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "mime",
- "rustversion",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -419,13 +397,13 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -455,21 +433,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
@@ -594,6 +560,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -687,6 +655,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,12 +750,6 @@ dependencies = [
  "cfg-if",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-serialize"
@@ -1118,17 +1089,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,7 +1117,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common",
 ]
 
@@ -1257,7 +1216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b0cca3e7a10a4a3df37ea52c4cc7a53e5c9233489e03ee3f2829471fc3099a"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "cocoa 0.25.0",
  "core-foundation 0.9.4",
  "dioxus-cli-config",
@@ -1352,8 +1311,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe99b48a1348eec385b5c4bd3e80fd863b0d3b47257d34e2ddc58754dec5d128"
 dependencies = [
  "async-trait",
- "axum 0.7.9",
- "base64 0.22.1",
+ "axum",
+ "base64",
  "bytes",
  "ciborium",
  "dioxus-cli-config",
@@ -1369,8 +1328,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "generational-box",
- "http 1.4.0",
- "hyper 1.8.1",
+ "http",
+ "hyper",
  "once_cell",
  "parking_lot",
  "pin-project",
@@ -1478,7 +1437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff7e1701a498e214dd0c4a99fdb71c256405fc019a5c91663678ac975dd26ae6"
 dependencies = [
  "chrono",
- "http 1.4.0",
+ "http",
  "lru",
  "rustc-hash 1.1.0",
  "thiserror 1.0.69",
@@ -1509,7 +1468,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b78d90b5d593eb39e96d7892d059c085af5ac4c29b4257b22646e37c1c5ef0"
 dependencies = [
- "axum 0.7.9",
+ "axum",
  "dioxus-cli-config",
  "dioxus-core",
  "dioxus-devtools",
@@ -2059,6 +2018,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2461,7 +2426,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http 1.4.0",
+ "http",
  "js-sys",
  "pin-project",
  "serde",
@@ -2550,25 +2515,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.13.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -2578,7 +2524,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http",
  "indexmap 2.13.0",
  "slab",
  "tokio",
@@ -2632,10 +2578,10 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "headers-core",
- "http 1.4.0",
+ "http",
  "httpdate",
  "mime",
  "sha1",
@@ -2647,7 +2593,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -2721,17 +2667,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa 1.0.17",
-]
-
-[[package]]
-name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -2742,23 +2677,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -2769,8 +2693,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -2794,30 +2718,6 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa 1.0.17",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -2826,9 +2726,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa 1.0.17",
@@ -2848,9 +2748,9 @@ dependencies = [
  "bytes",
  "futures-util",
  "headers",
- "http 1.4.0",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "http",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
  "rustls-native-certs 0.7.3",
@@ -2861,28 +2761,12 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.4.0",
- "hyper 1.8.1",
+ "http",
+ "hyper",
  "hyper-util",
  "log",
  "rustls 0.23.36",
@@ -2896,23 +2780,11 @@ dependencies = [
 
 [[package]]
 name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper 0.14.32",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2927,7 +2799,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2941,14 +2813,14 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.8.1",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -3254,6 +3126,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3300,16 +3182,18 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
- "base64 0.22.1",
+ "aws-lc-rs",
+ "base64",
+ "getrandom 0.2.17",
  "js-sys",
  "pem",
- "ring",
  "serde",
  "serde_json",
+ "signature",
  "simple_asn1",
 ]
 
@@ -3319,7 +3203,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c75b990324f09bef15e791606b7b7a296d02fc88a344f6eba9390970a870ad5"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "serde",
  "serde-value",
@@ -3356,7 +3240,7 @@ dependencies = [
  "k8s-openapi",
  "ks-core",
  "kube",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3392,15 +3276,15 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arboard",
- "axum 0.7.9",
- "base64 0.22.1",
+ "axum",
+ "base64",
  "chrono",
  "dashmap 6.1.0",
  "dioxus",
  "dioxus-liveview",
  "futures",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "k8s-openapi",
  "ks-core",
@@ -3411,7 +3295,7 @@ dependencies = [
  "lucide-dioxus",
  "pulldown-cmark",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "rfd 0.15.4",
  "serde",
  "serde_json",
@@ -3446,19 +3330,19 @@ version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d34ad38cdfbd1fa87195d42569f57bb1dda6ba5f260ee32fef9570b7937a0c9"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "chrono",
  "either",
  "futures",
  "home",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-http-proxy",
- "hyper-rustls 0.27.7",
- "hyper-timeout 0.5.2",
+ "hyper-rustls",
+ "hyper-timeout",
  "hyper-util",
  "jsonpath-rust",
  "k8s-openapi",
@@ -3466,7 +3350,7 @@ dependencies = [
  "pem",
  "rand 0.8.5",
  "rustls 0.23.36",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "secrecy",
  "serde",
  "serde_json",
@@ -3488,7 +3372,7 @@ checksum = "97aa830b288a178a90e784d1b0f1539f2d200d2188c7b4a3146d9dc983d596f3"
 dependencies = [
  "chrono",
  "form_urlencoded",
- "http 1.4.0",
+ "http",
  "json-patch",
  "k8s-openapi",
  "schemars",
@@ -3564,9 +3448,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "libappindicator"
@@ -3607,12 +3488,6 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -3917,7 +3792,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 1.4.0",
+ "http",
  "httparse",
  "memchr",
  "mime",
@@ -4032,22 +3907,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.5",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4063,24 +3922,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -4481,17 +4328,8 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde_core",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -4708,27 +4546,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4914,9 +4731,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -4924,11 +4741,10 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "bytes",
  "heck 0.5.0",
  "itertools",
  "log",
@@ -4945,9 +4761,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
  "itertools",
@@ -4958,9 +4774,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
 ]
@@ -5278,62 +5094,21 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
- "tokio",
- "tokio-rustls 0.24.1",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots 0.25.4",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "cookie",
  "cookie_store",
  "futures-core",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -5348,7 +5123,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.26.4",
@@ -5421,28 +5196,8 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid",
- "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -5481,18 +5236,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
@@ -5511,6 +5254,7 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -5522,24 +5266,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe 0.1.6",
- "rustls-pemfile 1.0.4",
- "schannel",
- "security-framework 2.11.1",
-]
-
-[[package]]
-name = "rustls-native-certs"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe 0.1.6",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework 2.11.1",
@@ -5555,15 +5287,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.5.1",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -5587,23 +5310,13 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
 version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5612,9 +5325,10 @@ version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5682,16 +5396,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "secrecy"
@@ -5921,19 +5625,19 @@ version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fae7a3038a32e5a34ba32c6c45eb4852f8affaf8b794ebfcd4b1099e2d62ebe"
 dependencies = [
- "axum 0.7.9",
+ "axum",
  "bytes",
  "const_format",
  "dashmap 5.5.3",
  "futures",
  "gloo-net",
- "http 1.4.0",
+ "http",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "inventory",
  "js-sys",
  "once_cell",
- "reqwest 0.12.28",
+ "reqwest",
  "send_wrapper",
  "serde",
  "serde_json",
@@ -6047,7 +5751,6 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
  "rand_core 0.6.4",
 ]
 
@@ -6185,16 +5888,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6208,21 +5901,22 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strike48-connector"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01bb7c6a409699ea7606cb59fca48ee685ad4e753382d5b75cec8afd8be7c420"
+checksum = "29b8196da81adbdfafaac3b721f2cae3899c9d6e611ef454c4bd4248e99103d2"
 dependencies = [
  "async-stream",
  "async-trait",
- "base64 0.21.7",
+ "aws-lc-rs",
+ "base64",
  "bytes",
  "chrono",
  "futures",
  "futures-util",
  "hex",
  "hostname 0.3.1",
- "http 1.4.0",
- "hyper-rustls 0.24.2",
+ "http",
+ "hyper-util",
  "jsonwebtoken",
  "metrics",
  "native-tls",
@@ -6231,10 +5925,8 @@ dependencies = [
  "prost-types",
  "rand 0.8.5",
  "regex",
- "reqwest 0.11.27",
- "rsa",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "reqwest",
+ "rustls 0.23.36",
  "schemars",
  "serde",
  "serde_json",
@@ -6243,10 +5935,9 @@ dependencies = [
  "sysinfo",
  "thiserror 1.0.69",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls 0.26.4",
  "tokio-tungstenite 0.21.0",
- "tonic 0.11.0",
- "tonic-rustls",
+ "tonic",
  "tower-service",
  "tracing",
  "tracing-subscriber",
@@ -6256,13 +5947,13 @@ dependencies = [
 
 [[package]]
 name = "strike48-proto"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420fb873cd05b44b6a4782deee4aa4b8197d2fc4e5a1d2b0254e7577a0a435ac"
+checksum = "0b1001a2bab20e1672b52cc7093dd14a41994bd4a21aba5c41dc80f94a40c712"
 dependencies = [
  "prost",
  "prost-types",
- "tonic 0.11.0",
+ "tonic",
  "tonic-build",
 ]
 
@@ -6327,12 +6018,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -6363,27 +6048,6 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "windows 0.62.2",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -6624,16 +6288,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd86198d9ee903fedd2f9a2e72014287c0d9167e4ae43b5853007205dda1b76"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6651,16 +6305,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
  "tokio",
 ]
 
@@ -6832,49 +6476,30 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.6.20",
- "base64 0.21.7",
- "bytes",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-timeout 0.4.1",
- "percent-encoding",
- "pin-project",
- "prost",
- "rustls-native-certs 0.7.3",
- "rustls-pemfile 2.2.0",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls 0.25.0",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
- "axum 0.7.9",
- "base64 0.22.1",
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
  "bytes",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
+ "prost",
+ "rustls-native-certs 0.8.3",
+ "rustls-pemfile",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
@@ -6884,42 +6509,16 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.11.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
+ "prost-types",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "tonic-rustls"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803689f99cfc6de9c3b27aa86bf98553754c72c53b715913f1c14dcd3c030f77"
-dependencies = [
- "async-stream",
- "bytes",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-timeout 0.5.2",
- "hyper-util",
- "pin-project",
- "socket2 0.5.10",
- "tokio",
- "tokio-rustls 0.26.4",
- "tokio-stream",
- "tonic 0.12.3",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -6950,10 +6549,8 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.0",
  "pin-project-lite",
- "slab",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -6970,8 +6567,8 @@ dependencies = [
  "bitflags 2.10.0",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -6992,12 +6589,12 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bitflags 2.10.0",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "iri-string",
  "mime",
  "pin-project-lite",
@@ -7138,7 +6735,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http",
  "httparse",
  "log",
  "native-tls",
@@ -7160,7 +6757,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -7178,7 +6775,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -7195,7 +6792,7 @@ checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http",
  "httparse",
  "log",
  "rand 0.9.2",
@@ -7262,6 +6859,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -7610,12 +7213,6 @@ dependencies = [
  "soup3-sys",
  "system-deps",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
@@ -8207,16 +7804,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8234,7 +7821,7 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac0099a336829fbf54c26b5f620c68980ebbe37196772aeaf6118df4931b5cb0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "block",
  "cocoa 0.26.1",
  "core-graphics 0.24.0",
@@ -8244,7 +7831,7 @@ dependencies = [
  "gdkx11",
  "gtk",
  "html5ever",
- "http 1.4.0",
+ "http",
  "javascriptcore-rs",
  "jni",
  "kuchikiki",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2755,7 +2755,7 @@ dependencies = [
  "pin-project-lite",
  "rustls-native-certs 0.7.3",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -2769,11 +2769,11 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rustls 0.23.36",
+ "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.6",
 ]
@@ -3297,13 +3297,15 @@ dependencies = [
  "regex",
  "reqwest",
  "rfd 0.15.4",
+ "ring",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
  "strike48-connector",
  "strike48-proto",
  "tokio",
- "tokio-tungstenite 0.21.0",
+ "tokio-tungstenite 0.26.2",
  "tokio-util",
  "tower-service",
  "tracing",
@@ -3349,7 +3351,7 @@ dependencies = [
  "kube-core",
  "pem",
  "rand 0.8.5",
- "rustls 0.23.36",
+ "rustls",
  "rustls-pemfile",
  "secrecy",
  "serde",
@@ -4852,7 +4854,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.36",
+ "rustls",
  "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
@@ -4872,7 +4874,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.36",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -5118,7 +5120,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.36",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5126,7 +5128,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.8",
@@ -5236,20 +5238,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
@@ -5259,7 +5247,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -5306,17 +5294,6 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5901,9 +5878,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strike48-connector"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b8196da81adbdfafaac3b721f2cae3899c9d6e611ef454c4bd4248e99103d2"
+checksum = "9e0a5a1759ad71297dca323c31b3275d9145aab70f196dc165279b4b72b40665"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5926,7 +5903,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "reqwest",
- "rustls 0.23.36",
+ "rustls",
  "schemars",
  "serde",
  "serde_json",
@@ -5935,8 +5912,8 @@ dependencies = [
  "sysinfo",
  "thiserror 1.0.69",
  "tokio",
- "tokio-rustls 0.26.4",
- "tokio-tungstenite 0.21.0",
+ "tokio-rustls",
+ "tokio-tungstenite 0.26.2",
  "tonic",
  "tower-service",
  "tracing",
@@ -5947,9 +5924,9 @@ dependencies = [
 
 [[package]]
 name = "strike48-proto"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1001a2bab20e1672b52cc7093dd14a41994bd4a21aba5c41dc80f94a40c712"
+checksum = "00b97b38bf36f964d7d06f3a3505d76c043a7f01fcda6151283585d7162dc9b5"
 dependencies = [
  "prost",
  "prost-types",
@@ -6310,22 +6287,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.36",
+ "rustls",
  "tokio",
 ]
 
@@ -6339,24 +6305,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
-dependencies = [
- "futures-util",
- "log",
- "native-tls",
- "rustls 0.22.4",
- "rustls-pki-types",
- "tokio",
- "tokio-native-tls",
- "tokio-rustls 0.25.0",
- "tungstenite 0.21.0",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -6379,8 +6327,14 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
+ "tokio-native-tls",
+ "tokio-rustls",
  "tungstenite 0.26.2",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -6499,7 +6453,7 @@ dependencies = [
  "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
@@ -6728,28 +6682,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "native-tls",
- "rand 0.8.5",
- "rustls 0.22.4",
- "rustls-pki-types",
- "sha1",
- "thiserror 1.0.69",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
@@ -6795,7 +6727,10 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,8 +55,8 @@ tokio-tungstenite = { version = "0.21", features = ["rustls-tls-webpki-roots"] }
 dashmap = "6"
 
 # Connector SDK
-strike48-connector = "0.3.2"
-strike48-proto = "0.3.2"
+strike48-connector = "0.3.3"
+strike48-proto = "0.3.3"
 
 # Web server (for connector mode)
 axum = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,8 +55,8 @@ tokio-tungstenite = { version = "0.21", features = ["rustls-tls-webpki-roots"] }
 dashmap = "6"
 
 # Connector SDK
-strike48-connector = "0.3.1"
-strike48-proto = "0.3.1"
+strike48-connector = "0.3.2"
+strike48-proto = "0.3.2"
 
 # Web server (for connector mode)
 axum = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,14 +49,14 @@ dirs = "5"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 # WebSocket (for connector proxy)
-tokio-tungstenite = { version = "0.21", features = ["rustls-tls-webpki-roots"] }
+tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
 
 # Concurrent map (for WS connection tracking)
 dashmap = "6"
 
-# Connector SDK
-strike48-connector = "0.3.3"
-strike48-proto = "0.3.3"
+# Strike48 Connector SDK
+strike48-connector = "0.3.4"
+strike48-proto = "0.3.4"
 
 # Web server (for connector mode)
 axum = "0.7"

--- a/crates/ks-ui/Cargo.toml
+++ b/crates/ks-ui/Cargo.toml
@@ -11,7 +11,7 @@ desktop = ["dioxus/desktop", "dep:arboard", "dep:rfd"]
 fullstack = ["dioxus/fullstack", "dioxus/server"]
 liveview = ["dep:dioxus-liveview"]
 server = ["liveview", "dep:axum"]
-connector = ["liveview", "dep:strike48-connector", "dep:strike48-proto", "dep:reqwest", "dep:tokio-tungstenite", "dep:dashmap", "dep:anyhow", "dep:axum", "dep:regex", "dep:base64", "dep:urlencoding", "dep:hyper", "dep:hyper-util", "dep:http-body-util", "dep:tower-service"]
+connector = ["liveview", "dep:strike48-connector", "dep:strike48-proto", "dep:reqwest", "dep:tokio-tungstenite", "dep:dashmap", "dep:anyhow", "dep:axum", "dep:regex", "dep:base64", "dep:urlencoding", "dep:ring", "dep:rustls", "dep:hyper", "dep:hyper-util", "dep:http-body-util", "dep:tower-service"]
 
 [lib]
 name = "ks_ui"
@@ -73,6 +73,8 @@ axum = { workspace = true, optional = true }
 regex = { version = "1", optional = true }
 base64 = { version = "0.22", optional = true }
 urlencoding = { version = "2", optional = true }
+ring = { version = "0.17", optional = true }
+rustls = { version = "0.23", optional = true, default-features = false, features = ["ring"] }
 hyper = { workspace = true, optional = true }
 hyper-util = { workspace = true, optional = true }
 http-body-util = { workspace = true, optional = true }

--- a/crates/ks-ui/Cargo.toml
+++ b/crates/ks-ui/Cargo.toml
@@ -11,7 +11,7 @@ desktop = ["dioxus/desktop", "dep:arboard", "dep:rfd"]
 fullstack = ["dioxus/fullstack", "dioxus/server"]
 liveview = ["dep:dioxus-liveview"]
 server = ["liveview", "dep:axum"]
-connector = ["liveview", "dep:strike48-connector", "dep:strike48-proto", "dep:reqwest", "dep:tokio-tungstenite", "dep:dashmap", "dep:anyhow", "dep:axum", "dep:regex", "dep:base64", "dep:rsa", "dep:rand", "dep:jsonwebtoken", "dep:uuid", "dep:urlencoding", "dep:hyper", "dep:hyper-util", "dep:http-body-util", "dep:tower-service"]
+connector = ["liveview", "dep:strike48-connector", "dep:strike48-proto", "dep:reqwest", "dep:tokio-tungstenite", "dep:dashmap", "dep:anyhow", "dep:axum", "dep:regex", "dep:base64", "dep:urlencoding", "dep:hyper", "dep:hyper-util", "dep:http-body-util", "dep:tower-service"]
 
 [lib]
 name = "ks_ui"
@@ -72,10 +72,6 @@ anyhow = { workspace = true, optional = true }
 axum = { workspace = true, optional = true }
 regex = { version = "1", optional = true }
 base64 = { version = "0.22", optional = true }
-rsa = { version = "0.9", optional = true, features = ["std"] }
-rand = { version = "0.8", optional = true }
-jsonwebtoken = { version = "9", optional = true }
-uuid = { version = "1", optional = true, features = ["v4"] }
 urlencoding = { version = "2", optional = true }
 hyper = { workspace = true, optional = true }
 hyper-util = { workspace = true, optional = true }

--- a/crates/ks-ui/src/bin/ks-connector.rs
+++ b/crates/ks-ui/src/bin/ks-connector.rs
@@ -776,7 +776,7 @@ impl StudioKubeConnector {
                             Err(_) => data,
                         };
 
-                        let msg = WsMessage::Binary(decoded);
+                        let msg = WsMessage::Binary(decoded.into());
                         if let Err(e) = ws_sink.send(msg).await {
                             tracing::error!("Error sending to backend WS {}: {}", conn_id_write, e);
                             break;
@@ -794,7 +794,7 @@ impl StudioKubeConnector {
                                 let (frame_type, data) = match msg {
                                     WsMessage::Text(text) => (
                                         WebSocketFrameType::WebsocketFrameTypeText,
-                                        text.into_bytes(),
+                                        text.as_bytes().to_vec(),
                                     ),
                                     WsMessage::Binary(data) => (
                                         WebSocketFrameType::WebsocketFrameTypeBinary,
@@ -1620,6 +1620,9 @@ async fn run_message_loop(
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Install ring as the default rustls CryptoProvider (required since rustls 0.23+).
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     tracing_subscriber::fmt::init();
 
     tracing::info!("Starting KubeStudio Connector");

--- a/crates/ks-ui/src/bin/ks-connector.rs
+++ b/crates/ks-ui/src/bin/ks-connector.rs
@@ -32,10 +32,9 @@ use strike48_connector::{
     ConnectorClient, ConnectorConfig, NavigationConfig, OttProvider, PayloadEncoding,
 };
 use strike48_proto::proto::{
-    self, ConnectorCapabilities, ExecuteResponse, HeartbeatRequest,
-    InstanceMetadata, RegisterConnectorRequest, StreamMessage, WebSocketCloseRequest,
-    WebSocketFrame, WebSocketFrameType, WebSocketOpenRequest, WebSocketOpenResponse,
-    stream_message::Message,
+    self, ConnectorCapabilities, ExecuteResponse, HeartbeatRequest, InstanceMetadata,
+    RegisterConnectorRequest, StreamMessage, WebSocketCloseRequest, WebSocketFrame,
+    WebSocketFrameType, WebSocketOpenRequest, WebSocketOpenResponse, stream_message::Message,
 };
 use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
@@ -1437,7 +1436,6 @@ fn build_http_client() -> reqwest::Client {
         .unwrap_or_else(|_| reqwest::Client::new())
 }
 
-
 /// Sleep that can be interrupted by shutdown
 async fn sleep_with_shutdown(duration: tokio::time::Duration, shutdown: &AtomicBool) -> bool {
     let interval = tokio::time::Duration::from_millis(100);
@@ -1793,7 +1791,10 @@ async fn main() -> anyhow::Result<()> {
                 .await
             {
                 Ok(creds) => {
-                    tracing::info!("OTT pre-approval registration successful: {}", creds.client_id);
+                    tracing::info!(
+                        "OTT pre-approval registration successful: {}",
+                        creds.client_id
+                    );
                     ott_provider = Some(provider);
                 }
                 Err(e) => {

--- a/crates/ks-ui/src/bin/ks-connector.rs
+++ b/crates/ks-ui/src/bin/ks-connector.rs
@@ -20,11 +20,8 @@ use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use dashmap::DashMap;
 use dioxus_liveview::LiveviewRouter as _;
 use futures::{SinkExt, StreamExt};
-use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use ks_kube::{KubeClient, PermissionMode, Toolbox, auth, cleanup_orphaned_toolbox};
-use rsa::{RsaPrivateKey, RsaPublicKey, pkcs1::EncodeRsaPrivateKey, pkcs8::EncodePublicKey};
 use std::collections::HashMap;
-use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -32,10 +29,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 use strike48_connector::{
     AppManifest, AppPageRequest, AppPageResponse, BodyEncoding, ClientOptions, ConnectorBehavior,
-    ConnectorClient, ConnectorConfig, NavigationConfig, PayloadEncoding,
+    ConnectorClient, ConnectorConfig, NavigationConfig, OttProvider, PayloadEncoding,
 };
 use strike48_proto::proto::{
-    self, ConnectorCapabilities, CredentialsIssued, ExecuteResponse, HeartbeatRequest,
+    self, ConnectorCapabilities, ExecuteResponse, HeartbeatRequest,
     InstanceMetadata, RegisterConnectorRequest, StreamMessage, WebSocketCloseRequest,
     WebSocketFrame, WebSocketFrameType, WebSocketOpenRequest, WebSocketOpenResponse,
     stream_message::Message,
@@ -1426,320 +1423,20 @@ fn build_registration_message(
     }
 }
 
-/// Credentials returned from OTT registration
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-struct OttCredentials {
-    client_id: String,
-    keycloak_url: String,
-    tenant_id: String,
-}
+// Auth is handled entirely by the SDK's OttProvider which manages
+// credential storage, key generation, and token refresh.
 
-/// Get keys directory path
-fn get_keys_dir() -> PathBuf {
-    if let Ok(dir) = std::env::var("MATRIX_KEYS_DIR") {
-        return PathBuf::from(dir);
-    }
-    home_dir().join(".matrix").join("keys")
-}
-
-/// Get private key path for this connector
-fn get_private_key_path(connector_type: &str, instance_id: &str) -> PathBuf {
-    get_keys_dir().join(format!("{}_{}.pem", connector_type, instance_id))
-}
-
-/// Get credentials file path
-fn get_credentials_path(connector_type: &str, instance_id: &str) -> PathBuf {
-    home_dir()
-        .join(".matrix")
-        .join("credentials")
-        .join(format!("{}_{}.json", connector_type, instance_id))
-}
-
-/// Cross-platform home directory (uses $HOME on Unix, %USERPROFILE% on Windows).
-fn home_dir() -> PathBuf {
-    #[cfg(unix)]
-    {
-        std::env::var("HOME")
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| PathBuf::from("."))
-    }
-    #[cfg(windows)]
-    {
-        std::env::var("USERPROFILE")
-            .or_else(|_| std::env::var("HOME"))
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| PathBuf::from("."))
-    }
-}
-
-/// Load or generate RSA keypair for this connector
-fn get_or_create_keypair(
-    connector_type: &str,
-    instance_id: &str,
-) -> anyhow::Result<(RsaPrivateKey, String)> {
-    let key_path = get_private_key_path(connector_type, instance_id);
-
-    if key_path.exists() {
-        // Load existing keypair
-        let key_pem = fs::read_to_string(&key_path)?;
-        let private_key = rsa::pkcs1::DecodeRsaPrivateKey::from_pkcs1_pem(&key_pem)
-            .map_err(|e| anyhow::anyhow!("Failed to parse private key: {}", e))?;
-        let public_key = RsaPublicKey::from(&private_key);
-        let public_key_pem = public_key.to_public_key_pem(rsa::pkcs8::LineEnding::LF)?;
-        tracing::info!("Loaded existing keypair from {}", key_path.display());
-        return Ok((private_key, public_key_pem));
-    }
-
-    // Generate new keypair
-    tracing::info!("Generating new RSA keypair...");
-    let mut rng = rand::thread_rng();
-    let private_key = RsaPrivateKey::new(&mut rng, 2048)?;
-    let public_key = RsaPublicKey::from(&private_key);
-
-    // Save private key
-    let keys_dir = get_keys_dir();
-    if !keys_dir.exists() {
-        fs::create_dir_all(&keys_dir)?;
-    }
-
-    let private_key_pem = private_key.to_pkcs1_pem(rsa::pkcs1::LineEnding::LF)?;
-    fs::write(&key_path, private_key_pem.as_bytes())?;
-
-    // Set permissions (Unix only)
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(&key_path)?.permissions();
-        perms.set_mode(0o600);
-        fs::set_permissions(&key_path, perms)?;
-    }
-
-    let public_key_pem = public_key.to_public_key_pem(rsa::pkcs8::LineEnding::LF)?;
-    tracing::info!("Saved new keypair to {}", key_path.display());
-
-    Ok((private_key, public_key_pem))
-}
-
-/// Save credentials to disk
-fn save_credentials(
-    connector_type: &str,
-    instance_id: &str,
-    credentials: &OttCredentials,
-) -> anyhow::Result<()> {
-    let creds_path = get_credentials_path(connector_type, instance_id);
-    if let Some(parent) = creds_path.parent()
-        && !parent.exists()
-    {
-        fs::create_dir_all(parent)?;
-    }
-    let json = serde_json::to_string_pretty(credentials)?;
-    fs::write(&creds_path, json)?;
-    tracing::info!("Saved credentials to {}", creds_path.display());
-    Ok(())
-}
-
-/// Load saved credentials from disk
-fn load_saved_credentials(connector_type: &str, instance_id: &str) -> Option<OttCredentials> {
-    let creds_path = get_credentials_path(connector_type, instance_id);
-    if creds_path.exists()
-        && let Ok(data) = fs::read_to_string(&creds_path)
-        && let Ok(creds) = serde_json::from_str(&data)
-    {
-        tracing::info!("Loaded saved credentials from {}", creds_path.display());
-        return Some(creds);
-    }
-    None
-}
-
-/// Create JWT client assertion for private_key_jwt authentication
-fn create_client_assertion(
-    private_key: &RsaPrivateKey,
-    credentials: &OttCredentials,
-) -> anyhow::Result<String> {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-
-    let claims = serde_json::json!({
-        "iss": credentials.client_id,
-        "sub": credentials.client_id,
-        "aud": credentials.keycloak_url,
-        "exp": now + 60,
-        "iat": now,
-        "jti": uuid::Uuid::new_v4().to_string(),
-    });
-
-    let private_key_pem = private_key.to_pkcs1_pem(rsa::pkcs1::LineEnding::LF)?;
-    let encoding_key = EncodingKey::from_rsa_pem(private_key_pem.as_bytes())?;
-    let header = Header::new(Algorithm::RS256);
-
-    Ok(encode(&header, &claims, &encoding_key)?)
-}
-
-/// Build a reqwest client that respects MATRIX_TLS_INSECURE
+/// Build a reqwest client that respects MATRIX_TLS_INSECURE.
 fn build_http_client() -> reqwest::Client {
     let insecure = std::env::var("MATRIX_TLS_INSECURE")
         .map(|v| v == "true" || v == "1")
         .unwrap_or(false);
-
     reqwest::Client::builder()
         .danger_accept_invalid_certs(insecure)
         .build()
         .unwrap_or_else(|_| reqwest::Client::new())
 }
 
-/// Get access token from Keycloak using private_key_jwt
-async fn get_access_token(
-    private_key: &RsaPrivateKey,
-    credentials: &OttCredentials,
-) -> anyhow::Result<String> {
-    let client_assertion = create_client_assertion(private_key, credentials)?;
-
-    let token_url = format!(
-        "{}/protocol/openid-connect/token",
-        credentials.keycloak_url.trim_end_matches('/')
-    );
-
-    tracing::info!("Getting access token from {}", token_url);
-
-    let client = build_http_client();
-    let response = client
-        .post(&token_url)
-        .form(&[
-            ("grant_type", "client_credentials"),
-            ("client_id", &credentials.client_id),
-            (
-                "client_assertion_type",
-                "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-            ),
-            ("client_assertion", &client_assertion),
-        ])
-        .send()
-        .await?;
-
-    if response.status().is_success() {
-        #[derive(serde::Deserialize)]
-        struct TokenResponse {
-            access_token: String,
-        }
-        let token_resp: TokenResponse = response.json().await?;
-        tracing::info!("Access token obtained successfully");
-        Ok(token_resp.access_token)
-    } else {
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        anyhow::bail!("Token request failed: {} - {}", status, body);
-    }
-}
-
-/// Register with OTT and get credentials (including client_id for JWT auth)
-async fn register_with_ott(
-    creds: &CredentialsIssued,
-    config: &ConnectorConfig,
-) -> anyhow::Result<(OttCredentials, RsaPrivateKey)> {
-    // In StrikeHub mode, always use the server-provided URL for OTT registration
-    // because STRIKE48_API_URL points to StrikeHub's local auth proxy which
-    // doesn't have the /api/connectors/register-with-ott endpoint.
-    let api_base = if std::env::var("STRIKEHUB_SOCKET").is_ok() {
-        String::new()
-    } else {
-        std::env::var("STRIKE48_API_URL").unwrap_or_default()
-    };
-    let base_url = if api_base.is_empty() {
-        &creds.matrix_api_url
-    } else {
-        &api_base
-    };
-    let register_url = format!("{}{}", base_url, creds.register_url);
-    tracing::info!("Registering with OTT at: {}", register_url);
-
-    // Get or create RSA keypair
-    let (private_key, public_key_pem) =
-        get_or_create_keypair(&config.connector_type, &config.instance_id)?;
-
-    let payload = serde_json::json!({
-        "token": creds.ott,
-        "public_key": public_key_pem,
-        "connector_type": config.connector_type,
-        "instance_id": config.instance_id,
-    });
-
-    tracing::debug!(
-        "OTT registration payload: connector_type={}, instance_id={}",
-        config.connector_type,
-        config.instance_id
-    );
-
-    let client = build_http_client();
-
-    // Retry logic for cluster sync delays
-    const MAX_RETRIES: u32 = 4;
-    let mut last_error = String::new();
-
-    for attempt in 0..MAX_RETRIES {
-        if attempt > 0 {
-            let delay = std::cmp::min(500 * 2_u64.pow(attempt - 1), 3000);
-            tracing::warn!(
-                "OTT registration retry {}/{} after {}ms",
-                attempt + 1,
-                MAX_RETRIES,
-                delay
-            );
-            tokio::time::sleep(tokio::time::Duration::from_millis(delay)).await;
-        }
-
-        let response = match client.post(&register_url).json(&payload).send().await {
-            Ok(resp) => resp,
-            Err(e) => {
-                last_error = format!("HTTP request failed: {}", e);
-                continue;
-            }
-        };
-
-        if response.status().is_success() {
-            let credentials: OttCredentials = response.json().await?;
-
-            // Save credentials to disk
-            save_credentials(&config.connector_type, &config.instance_id, &credentials)?;
-
-            return Ok((credentials, private_key));
-        }
-
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-
-        if status.as_u16() == 401 && body.contains("Invalid or expired") {
-            // Possible cluster sync delay - retry
-            last_error = body;
-            continue;
-        }
-
-        anyhow::bail!(
-            "Registration failed: {} {} - URL: {} - Body: {}",
-            status.as_u16(),
-            status.canonical_reason().unwrap_or("Unknown"),
-            register_url,
-            if body.is_empty() {
-                "(empty response)"
-            } else {
-                &body
-            }
-        );
-    }
-
-    anyhow::bail!(
-        "Registration failed after {} retries: {}",
-        MAX_RETRIES,
-        last_error
-    );
-}
-
-/// Auth context for reconnection
-struct AuthContext {
-    credentials: OttCredentials,
-    private_key: RsaPrivateKey,
-}
 
 /// Sleep that can be interrupted by shutdown
 async fn sleep_with_shutdown(duration: tokio::time::Duration, shutdown: &AtomicBool) -> bool {
@@ -1755,14 +1452,13 @@ async fn sleep_with_shutdown(duration: tokio::time::Duration, shutdown: &AtomicB
     false // Normal completion
 }
 
-/// Result of message loop - whether to reconnect and with what auth
-#[allow(clippy::large_enum_variant)]
+/// Result of message loop — why the stream ended.
 enum MessageLoopResult {
-    /// Stream closed normally or shutdown requested
+    /// Stream closed normally or shutdown requested.
     Exit,
-    /// Need to reconnect with new credentials
-    Reconnect(AuthContext),
-    /// Registration rejected due to invalid/untrusted JWT credentials
+    /// Post-approval credentials received; reconnect with JWT.
+    Reconnect,
+    /// Registration rejected due to invalid/untrusted JWT credentials.
     AuthFailure,
 }
 
@@ -1770,8 +1466,9 @@ enum MessageLoopResult {
 async fn run_message_loop(
     connector: Arc<StudioKubeConnector>,
     mut rx: mpsc::UnboundedReceiver<StreamMessage>,
-    config: &ConnectorConfig,
+    config: &mut ConnectorConfig,
     shutdown: &AtomicBool,
+    ott_provider: &mut Option<OttProvider>,
 ) -> MessageLoopResult {
     // Application-level heartbeat interval (30s) to keep the server session alive.
     // The server reaps sessions after 90s of inactivity. HTTP/2 PING frames do NOT
@@ -1859,26 +1556,59 @@ async fn run_message_loop(
                     }
                     Some(Message::CredentialsIssued(creds)) => {
                         tracing::info!(
-                            "Received CredentialsIssued - attempting OTT registration (api_url={}, register_url={})",
+                            "Received CredentialsIssued (api_url={}, register_url={})",
                             creds.matrix_api_url,
                             creds.register_url
                         );
 
-                        match register_with_ott(&creds, config).await {
-                            Ok((credentials, private_key)) => {
-                                tracing::info!("OTT registration successful, will reconnect with JWT");
-                                return MessageLoopResult::Reconnect(AuthContext {
-                                    credentials,
-                                    private_key,
-                                });
+                        // In StrikeHub mode, STRIKE48_API_URL points to the local
+                        // proxy which doesn't handle /api/connectors/register-with-ott,
+                        // so always use the server-provided URL.  In standalone mode,
+                        // prefer STRIKE48_API_URL if set.
+                        let api_url = if std::env::var("STRIKEHUB_SOCKET").is_ok() {
+                            creds.matrix_api_url.clone()
+                        } else {
+                            std::env::var("STRIKE48_API_URL")
+                                .ok()
+                                .filter(|s| !s.is_empty())
+                                .unwrap_or_else(|| creds.matrix_api_url.clone())
+                        };
+
+                        let mut provider = OttProvider::new(
+                            Some(config.connector_type.clone()),
+                            Some(config.instance_id.clone()),
+                        );
+
+                        match provider
+                            .register_public_key_with_ott_data(
+                                &creds.ott,
+                                &api_url,
+                                &creds.register_url,
+                                &config.connector_type,
+                                Some(&config.instance_id),
+                            )
+                            .await
+                        {
+                            Ok(resp) => {
+                                tracing::info!("OTT registration successful: {}", resp.client_id);
+                                match provider.get_token().await {
+                                    Ok(token) => {
+                                        tracing::info!("Got JWT via OttProvider, will reconnect");
+                                        config.auth_token = token;
+                                        *ott_provider = Some(provider);
+                                        return MessageLoopResult::Reconnect;
+                                    }
+                                    Err(e) => {
+                                        tracing::error!("OTT registration succeeded but get_token() failed: {}", e);
+                                    }
+                                }
                             }
                             Err(e) => {
                                 tracing::error!(
-                                    "OTT registration failed: {} (matrix_api_url={}, register_url={}, STRIKE48_API_URL={:?})",
+                                    "OTT registration failed: {} (api_url={}, register_url={})",
                                     e,
-                                    creds.matrix_api_url,
+                                    api_url,
                                     creds.register_url,
-                                    std::env::var("STRIKE48_API_URL").ok()
                                 );
                             }
                         }
@@ -2046,26 +1776,43 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    // Try to load saved credentials first
-    let mut auth_context: Option<AuthContext> = None;
+    // SDK OttProvider handles saved credentials, OTT pre-approval,
+    // key management, and token refresh — matching pick's pattern.
+    let mut ott_provider: Option<OttProvider> = None;
+    {
+        let mut provider = OttProvider::new(
+            Some(config.connector_type.clone()),
+            Some(config.instance_id.clone()),
+        );
 
-    if let Some(saved_creds) = load_saved_credentials(&config.connector_type, &config.instance_id) {
-        // Check if we have a corresponding private key
-        let key_path = get_private_key_path(&config.connector_type, &config.instance_id);
-        if key_path.exists()
-            && let Ok(key_pem) = fs::read_to_string(&key_path)
-            && let Ok(private_key) = rsa::pkcs1::DecodeRsaPrivateKey::from_pkcs1_pem(&key_pem)
+        if provider.has_ott() {
+            // Pre-approval OTT from StrikeHub (STRIKE48_REGISTRATION_TOKEN).
+            tracing::info!("Pre-approval OTT detected, attempting registration via SDK");
+            match provider
+                .register_with_ott(&config.connector_type, Some(&config.instance_id))
+                .await
+            {
+                Ok(creds) => {
+                    tracing::info!("OTT pre-approval registration successful: {}", creds.client_id);
+                    ott_provider = Some(provider);
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "OTT pre-approval registration failed: {}. \
+                         Falling through to gRPC registration (will require admin approval).",
+                        e
+                    );
+                }
+            }
+        } else if provider
+            .load_saved_credentials(&config.connector_type, Some(&config.instance_id))
+            .is_some()
         {
-            tracing::info!("Loaded saved credentials, will use JWT authentication");
-            auth_context = Some(AuthContext {
-                credentials: saved_creds,
-                private_key,
-            });
+            tracing::info!("Loaded saved credentials via SDK OttProvider");
+            ott_provider = Some(provider);
         }
     }
 
-    // Track consecutive auth failures so we can clear stale credentials
-    // and fall back to fresh OTT registration instead of looping forever.
     let mut consecutive_auth_failures: u32 = 0;
     const MAX_AUTH_FAILURES: u32 = 3;
 
@@ -2075,23 +1822,20 @@ async fn main() -> anyhow::Result<()> {
             break;
         }
 
-        // Get JWT token if we have credentials
-        let jwt_token = if let Some(ref ctx) = auth_context {
-            match get_access_token(&ctx.private_key, &ctx.credentials).await {
+        // Get fresh JWT via SDK OttProvider (handles private_key_jwt + caching).
+        if let Some(ref mut provider) = ott_provider {
+            match provider.get_token().await {
                 Ok(token) => {
-                    tracing::info!("Got access token from Keycloak");
-                    Some(token)
+                    tracing::info!("Got JWT via OttProvider (len={})", token.len());
+                    config.auth_token = token;
                 }
                 Err(e) => {
-                    tracing::error!("Failed to get access token: {}", e);
-                    // Clear auth context and try fresh registration
-                    auth_context = None;
-                    None
+                    tracing::warn!("Failed to get JWT from OttProvider: {}", e);
+                    config.auth_token.clear();
+                    ott_provider = None;
                 }
             }
-        } else {
-            None
-        };
+        }
 
         // Create client and connect (SDK auto-detects transport from URL scheme)
         #[allow(deprecated)]
@@ -2110,10 +1854,10 @@ async fn main() -> anyhow::Result<()> {
 
         tracing::info!("Connected to Matrix, starting stream...");
 
-        // Build registration message (with JWT if we have one)
+        // Build registration message — config.auth_token is set by OttProvider above.
         let registration_msg = build_registration_message(
             &config,
-            jwt_token.as_deref(),
+            None,
             default_cluster_name.as_deref(),
             explicit_connector_name.as_deref(),
         );
@@ -2142,11 +1886,10 @@ async fn main() -> anyhow::Result<()> {
         tracing::info!("Waiting for registration response...");
 
         // Run message loop
-        match run_message_loop(connector, rx, &config, &shutdown).await {
-            MessageLoopResult::Reconnect(ctx) => {
+        match run_message_loop(connector, rx, &mut config, &shutdown, &mut ott_provider).await {
+            MessageLoopResult::Reconnect => {
                 consecutive_auth_failures = 0;
                 tracing::info!("Reconnecting with JWT authentication...");
-                auth_context = Some(ctx);
                 if sleep_with_shutdown(tokio::time::Duration::from_millis(500), &shutdown).await {
                     break;
                 }
@@ -2158,19 +1901,8 @@ async fn main() -> anyhow::Result<()> {
                         "Registration rejected {} times in a row — clearing stale credentials and retrying fresh",
                         consecutive_auth_failures,
                     );
-                    // Remove saved credentials and keypair so the next
-                    // iteration falls through to post-approval OTT flow.
-                    let creds_path =
-                        get_credentials_path(&config.connector_type, &config.instance_id);
-                    let key_path =
-                        get_private_key_path(&config.connector_type, &config.instance_id);
-                    if creds_path.exists() {
-                        let _ = fs::remove_file(&creds_path);
-                    }
-                    if key_path.exists() {
-                        let _ = fs::remove_file(&key_path);
-                    }
-                    auth_context = None;
+                    ott_provider = None;
+                    config.auth_token.clear();
                     consecutive_auth_failures = 0;
                 } else {
                     tracing::warn!(
@@ -2188,14 +1920,12 @@ async fn main() -> anyhow::Result<()> {
                 if shutdown.load(Ordering::SeqCst) {
                     break;
                 }
-                if auth_context.is_some() {
-                    // We have credentials, so reconnect on disconnect
+                if ott_provider.is_some() {
                     tracing::info!("Connection closed, reconnecting...");
                     if sleep_with_shutdown(tokio::time::Duration::from_secs(2), &shutdown).await {
                         break;
                     }
                 } else {
-                    // No credentials, exit
                     break;
                 }
             }

--- a/deny.toml
+++ b/deny.toml
@@ -2,7 +2,6 @@
 version = 2
 ignore = [
     "RUSTSEC-2024-0370", # proc-macro-error is unmaintained, transitive dep
-    "RUSTSEC-2023-0071", # rsa timing sidechannel, no fix available
     # GTK3 bindings unmaintained (transitive from dioxus-desktop/wry)
     "RUSTSEC-2024-0411", # gdkwayland-sys
     "RUSTSEC-2024-0412", # gdk
@@ -19,8 +18,6 @@ ignore = [
     "RUSTSEC-2025-0057", # fxhash
     "RUSTSEC-2024-0384", # instant
     "RUSTSEC-2025-0134", # rustls-pemfile
-    "RUSTSEC-2024-0429", # glib unsound VariantStrIter
-    "RUSTSEC-2026-0002", # lru unsound IterMut
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -14,7 +14,6 @@ ignore = [
     "RUSTSEC-2024-0419", # gtk3-macros
     "RUSTSEC-2024-0420", # gtk-sys
     # Transitive vulnerabilities (no fix available upstream)
-    "RUSTSEC-2026-0049", # rustls-webpki 0.102.x CRL matching, via strike48-connector → tokio-tungstenite → rustls 0.22
     "RUSTSEC-2024-0429", # glib unsound VariantStrIter, via dioxus-desktop → wry → gtk
     "RUSTSEC-2026-0002", # lru unsound IterMut, via dioxus → dioxus-fullstack → dioxus-isrg
     # Other unmaintained transitive deps

--- a/deny.toml
+++ b/deny.toml
@@ -13,6 +13,10 @@ ignore = [
     "RUSTSEC-2024-0418", # gdk-sys
     "RUSTSEC-2024-0419", # gtk3-macros
     "RUSTSEC-2024-0420", # gtk-sys
+    # Transitive vulnerabilities (no fix available upstream)
+    "RUSTSEC-2026-0049", # rustls-webpki 0.102.x CRL matching, via strike48-connector → tokio-tungstenite → rustls 0.22
+    "RUSTSEC-2024-0429", # glib unsound VariantStrIter, via dioxus-desktop → wry → gtk
+    "RUSTSEC-2026-0002", # lru unsound IterMut, via dioxus → dioxus-fullstack → dioxus-isrg
     # Other unmaintained transitive deps
     "RUSTSEC-2025-0012", # backoff
     "RUSTSEC-2025-0057", # fxhash


### PR DESCRIPTION
## Summary

  Replace custom auth code in `ks-connector` with the SDK's `OttProvider`, matching pick's established pattern. Removes duplicate key generation, credential storage, JWT assertion, and OTT registration
  logic.

## Changes

  - **`ks-connector.rs`** (+104/-374): Remove `OttCredentials`, `AuthContext`, custom keypair generation, credential save/load, `create_client_assertion`, `get_access_token`, and `register_with_ott`. Delegate all
  auth lifecycle to SDK's `OttProvider`.
  - **`Cargo.toml`**: Remove orphaned deps (`rsa`, `rand`, `jsonwebtoken`, `uuid`) no longer needed after SDK delegation.

## How it works

  1. On startup, `OttProvider` checks for `STRIKE48_REGISTRATION_TOKEN` (OTT from StrikeHub) or saved credentials
  2. OTT registration and token refresh handled entirely by SDK (`private_key_jwt` grant)
  3. `STRIKEHUB_SOCKET` check preserved — when running under StrikeHub, uses server-provided `matrix_api_url` instead of local proxy
  4. `CredentialsIssued` handler (post-approval fallback) creates a new `OttProvider` for SDK-managed registration