### PR TITLE
fix: add rustls-tls-native-roots for OTT registration with local CAs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5121,6 +5121,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ rfd = "0.15"
 dirs = "5"
 
 # HTTP client (for connector proxy)
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "rustls-tls-native-roots"] }
 
 # WebSocket (for connector proxy)
 tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }

--- a/crates/ks-ui/src/bin/ks-connector.rs
+++ b/crates/ks-ui/src/bin/ks-connector.rs
@@ -1627,6 +1627,10 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!("Starting KubeStudio Connector");
     tracing::info!("================================");
+    tracing::info!(
+        "MATRIX_TLS_INSECURE={}",
+        std::env::var("MATRIX_TLS_INSECURE").unwrap_or_else(|_| "<unset>".to_string())
+    );
 
     // Build IPC address: StrikeHub provides a Unix socket path, otherwise PID-based
     let is_strikehub_mode;


### PR DESCRIPTION
## Summary

- Add `rustls-tls-native-roots` feature to reqwest so rustls trusts system CA certificates (macOS keychain, etc.) in addition to Mozilla's webpki-roots bundle
- Add `MATRIX_TLS_INSECURE` startup log line for TLS debuggability

## Problem

The SDK v0.3.4 `OttProvider` uses reqwest with `rustls-tls`, which only trusts Mozilla's CA bundle. When the Studio server (`studio.strike48.test`) uses a cert signed by a local/internal CA trusted in the macOS keychain but not in webpki-roots, the OTT HTTP POST fails:

```
error sending request for url (https://studio.strike48.test/api/connectors/register-with-ott):
  error trying to connect: invalid peer certificate: UnknownIssuer
```

The WebSocket transport was unaffected because it uses `native-tls` (via tokio-tungstenite), which trusts the OS cert store.

## Fix

`rustls-tls-native-roots` enables `rustls-native-certs`, which loads certificates from the OS trust store into rustls. This aligns the HTTP transport's CA trust with the WebSocket transport. No cert verification is disabled; the trust store is extended from Mozilla-only to Mozilla + OS (same as browsers).

`rustls-native-certs` was already a transitive dependency in the lockfile, so this adds no new supply-chain surface.

## Test plan

- [x] `cargo build --bin ks-connector --features connector` compiles
- [x] `cargo clippy --all-targets --features desktop -- -D warnings` passes
- [x] `cargo test --workspace --features desktop` passes (67 tests)
- [x] `just run` from strikehub: OTT pre-approval registration succeeds, connector reaches Online
