### PR TITLE
chore: fix ci failures, upgrade rustls-webpki

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5298,9 +5298,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/ks-ui/src/components/create_resource.rs
+++ b/crates/ks-ui/src/components/create_resource.rs
@@ -199,13 +199,12 @@ pub fn CreateResource(props: CreateResourceProps) -> Element {
                         // Textarea handles its own input (arrow keys, typing, etc.)
                         e.stop_propagation();
                     }
-                    CreateState::Success(_) | CreateState::Error(_) => {
-                        if crate::utils::is_escape(&e) || e.key() == Key::Enter {
+                    CreateState::Success(_) | CreateState::Error(_)
+                        if (crate::utils::is_escape(&e) || e.key() == Key::Enter) => {
                             on_close.call(());
                             e.stop_propagation();
                             e.prevent_default();
                         }
-                    }
                     _ => {}
                 }
             },

--- a/deny.toml
+++ b/deny.toml
@@ -13,9 +13,8 @@ ignore = [
     "RUSTSEC-2024-0418", # gdk-sys
     "RUSTSEC-2024-0419", # gtk3-macros
     "RUSTSEC-2024-0420", # gtk-sys
-    # Transitive vulnerabilities (no fix available upstream)
-    "RUSTSEC-2024-0429", # glib unsound VariantStrIter, via dioxus-desktop → wry → gtk
-    "RUSTSEC-2026-0002", # lru unsound IterMut, via dioxus → dioxus-fullstack → dioxus-isrg
+    # Transitive unsound advisories (no fix available upstream)
+    "RUSTSEC-2026-0097", # rand unsound with custom logger, transitive dep (multiple versions)
     # Other unmaintained transitive deps
     "RUSTSEC-2025-0012", # backoff
     "RUSTSEC-2025-0057", # fxhash


### PR DESCRIPTION
## Summary

Clean up CI failures across clippy, cargo-audit, and cargo-deny.

- Fix `collapsible_match` clippy lint by collapsing inner `if` into a match guard in `create_resource.rs`
- Upgrade `rustls-webpki` 0.103.10 → 0.103.13 to resolve RUSTSEC-2026-0098, RUSTSEC-2026-0099, RUSTSEC-2026-0104
- Remove stale `deny.toml` ignores for RUSTSEC-2024-0429 (glib) and RUSTSEC-2026-0002 (lru) that no longer match any crate in the lockfile
- Add `deny.toml` ignore for RUSTSEC-2026-0097 (rand unsound with custom logger, transitive dep)

## Test plan

- [ ] CI clippy passes (`cargo clippy --all-targets --features desktop -- -D warnings`)
- [ ] CI cargo-audit passes (`cargo audit --ignore RUSTSEC-2024-0370`)
- [ ] CI cargo-deny passes (no `advisory-not-detected` warnings)
