### PR TITLE
ci: disable macOS code signing by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,13 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      macos_signing:
+        description: 'Enable macOS code signing & notarization (requires active Apple developer account)'
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -100,7 +107,7 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }} --features desktop
 
       - name: Import Apple certificate
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && inputs.macos_signing == true
         env:
           APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -123,7 +130,7 @@ jobs:
           security list-keychains -d user -s $KEYCHAIN_PATH login.keychain-db
 
       - name: Sign macOS binary
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && inputs.macos_signing == true
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
@@ -133,7 +140,7 @@ jobs:
             target/${{ matrix.target }}/release/kubestudio
 
       - name: Notarize macOS binary
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && inputs.macos_signing == true
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
@@ -248,7 +255,7 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }} --bin ks-connector --features connector --no-default-features -p ks-ui
 
       - name: Import Apple certificate
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && inputs.macos_signing == true
         env:
           APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -271,7 +278,7 @@ jobs:
           security list-keychains -d user -s $KEYCHAIN_PATH login.keychain-db
 
       - name: Sign macOS binary
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && inputs.macos_signing == true
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
@@ -281,7 +288,7 @@ jobs:
             target/${{ matrix.target }}/release/ks-connector
 
       - name: Notarize macOS binary
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && inputs.macos_signing == true
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,10 @@ on:
       - 'v*'
   workflow_dispatch:
     inputs:
+      # TEMPORARY: macOS signing disabled by default during Apple developer account suspension.
+      # TODO: Change default back to true once account is restored.
       macos_signing:
-        description: 'Enable macOS code signing & notarization (requires active Apple developer account)'
+        description: 'Enable macOS code signing & notarization (default: false due to account suspension)'
         required: true
         default: false
         type: boolean
@@ -107,7 +109,7 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }} --features desktop
 
       - name: Import Apple certificate
-        if: runner.os == 'macOS' && inputs.macos_signing == true
+        if: runner.os == 'macOS' && inputs.macos_signing
         env:
           APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -130,7 +132,7 @@ jobs:
           security list-keychains -d user -s $KEYCHAIN_PATH login.keychain-db
 
       - name: Sign macOS binary
-        if: runner.os == 'macOS' && inputs.macos_signing == true
+        if: runner.os == 'macOS' && inputs.macos_signing
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
@@ -140,7 +142,7 @@ jobs:
             target/${{ matrix.target }}/release/kubestudio
 
       - name: Notarize macOS binary
-        if: runner.os == 'macOS' && inputs.macos_signing == true
+        if: runner.os == 'macOS' && inputs.macos_signing
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
@@ -255,7 +257,7 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }} --bin ks-connector --features connector --no-default-features -p ks-ui
 
       - name: Import Apple certificate
-        if: runner.os == 'macOS' && inputs.macos_signing == true
+        if: runner.os == 'macOS' && inputs.macos_signing
         env:
           APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -278,7 +280,7 @@ jobs:
           security list-keychains -d user -s $KEYCHAIN_PATH login.keychain-db
 
       - name: Sign macOS binary
-        if: runner.os == 'macOS' && inputs.macos_signing == true
+        if: runner.os == 'macOS' && inputs.macos_signing
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
@@ -288,7 +290,7 @@ jobs:
             target/${{ matrix.target }}/release/ks-connector
 
       - name: Notarize macOS binary
-        if: runner.os == 'macOS' && inputs.macos_signing == true
+        if: runner.os == 'macOS' && inputs.macos_signing
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             artifact: kubestudio-linux-x86_64
             name: Linux x86_64
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             artifact: kubestudio-darwin-x86_64
             name: macOS x86_64
@@ -215,7 +215,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             artifact: ks-connector-linux-x86_64
             name: Linux x86_64
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             artifact: ks-connector-darwin-x86_64
             name: macOS x86_64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             artifact: kubestudio-linux-x86_64
             name: Linux x86_64
-          - os: macos-latest
+          - os: macos-13
             target: x86_64-apple-darwin
             artifact: kubestudio-darwin-x86_64
             name: macOS x86_64
@@ -213,7 +213,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             artifact: ks-connector-linux-x86_64
             name: Linux x86_64
-          - os: macos-latest
+          - os: macos-13
             target: x86_64-apple-darwin
             artifact: ks-connector-darwin-x86_64
             name: macOS x86_64


### PR DESCRIPTION
## Summary

- Adds a `macos_signing` boolean input (default: **false**) via `workflow_dispatch` to the release workflow
- Gates all Apple certificate import, `codesign`, and `notarytool` notarization steps behind `inputs.macos_signing == true`
- macOS builds for both x86_64 and aarch64 still produce unsigned artifacts
- Windows and Linux builds are unaffected

## Context

The macOS developer account is temporarily suspended, causing all signing/notarization steps to fail on release runs.

## What's gated behind the flag

| Step | `build` job (desktop) | `build-connector` job |
|------|----------------------|----------------------|
| Import Apple certificate | gated | gated |
| `codesign` binary | gated | gated |
| `notarytool` submit + wait | gated | gated |

## Re-enabling signing

When the account is restored, either:
1. Run the release workflow via **workflow_dispatch** with `macos_signing: true`
2. Flip the default back to `true` in the workflow file

## Test plan

- [ ] Trigger a workflow_dispatch release with `macos_signing: false` — verify macOS builds succeed without signing
- [ ] Verify unsigned macOS artifacts are produced for both architectures
- [ ] Verify Windows/Linux builds are unaffected