### PR TITLE
ci: skip Docker builds on PRs, only run on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
 
   docker:
     name: Docker Build
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -2,10 +2,8 @@ name: Multi-Arch Docker
 
 on:
   push:
-    branches: [main, feat/multi-arch-scratch-image]
-    tags: ['v*']
-  pull_request:
     branches: [main]
+    tags: ['v*']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

- Adds `if: github.ref == 'refs/heads/main'` to the Docker Build job in `ci.yml` so it only runs on pushes to main, not on PRs
- Removes `pull_request` trigger from `docker-multiarch.yml` -- multi-arch builds with registry push are expensive and only needed on main and release tags
- Also cleans up stale `feat/multi-arch-scratch-image` branch from push trigger
- Matches the optimization applied to Pick in [PR #107](https://github.com/Strike48-public/pick/pull/107)

## Test plan

- [ ] Verify PR CI runs without the Docker Build job
- [ ] Verify Multi-Arch Docker workflow does not trigger on PRs
- [ ] Verify pushing to main still triggers both Docker workflows