### PR TITLE
fix(chart): preserve tini as PID 1 and drop $PATH dependency (#44)

### DIFF
--- a/chart/kubestudio/templates/_helpers.tpl
+++ b/chart/kubestudio/templates/_helpers.tpl
@@ -69,6 +69,14 @@ ks-server
 {{- end }}
 
 {{/*
+Absolute path of the binary inside the image. Using the absolute path avoids
+depending on the container's $PATH (see issue #44) and lets tini exec it directly.
+*/}}
+{{- define "kubestudio.binaryPath" -}}
+{{- printf "/usr/local/bin/%s" (include "kubestudio.binary" .) -}}
+{{- end }}
+
+{{/*
 Build KUBECONFIG env value from mounted secret keys.
 */}}
 {{- define "kubestudio.kubeconfigPaths" -}}

--- a/chart/kubestudio/templates/deployment.yaml
+++ b/chart/kubestudio/templates/deployment.yaml
@@ -35,7 +35,16 @@ spec:
         - name: kubestudio
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: [{{ include "kubestudio.binary" . | quote }}]
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          args:
+            {{- if .Values.args }}
+            {{- toYaml .Values.args | nindent 12 }}
+            {{- else }}
+            - {{ include "kubestudio.binaryPath" . | quote }}
+            {{- end }}
           env:
             - name: PORT
               value: {{ .Values.kubestudio.port | quote }}
@@ -84,6 +93,9 @@ spec:
             - name: MATRIX_TLS_INSECURE
               value: "true"
             {{- end }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
             - name: http

--- a/chart/kubestudio/values.yaml
+++ b/chart/kubestudio/values.yaml
@@ -12,6 +12,21 @@ fullnameOverride: ""
 
 replicaCount: 1
 
+# -- Container command override. When set, replaces the image ENTRYPOINT
+# (which is `tini --`). Leave empty to keep tini as PID 1 for proper signal
+# forwarding and zombie reaping.
+command: []
+
+# -- Container args override. When set, replaces the default binary invocation.
+# Defaults to the mode-selected binary at its absolute install path
+# (/usr/local/bin/ks-server or /usr/local/bin/ks-connector), which avoids
+# any dependency on the container's $PATH.
+args: []
+
+# -- Extra environment variables appended to the container's env list.
+# Standard Kubernetes env entries: `- name: FOO`, `value: "bar"` or `valueFrom: ...`.
+extraEnv: []
+
 kubestudio:
   # -- Permission mode: "read" (view-only) or "write" (allow edits)
   # Ignored when yolo=true (yolo grants cluster-admin).


### PR DESCRIPTION
## Summary
Fixes #44.

Removes the chart's bare `command: [ks-server]` override in `templates/deployment.yaml`, which was forcing Kubernetes to replace the image's `ENTRYPOINT` (`tini --`) and resolve the binary through the container's `$PATH`. The template now emits only `args: [/usr/local/bin/<binary>]`, preserving the image `ENTRYPOINT` (so `tini` remains PID 1) and eliminating the `$PATH` dependency by execing the binary via its absolute install path.

Also adds three escape-hatch value overrides (`command`, `args`, `extraEnv`) so operators can customize without forking the chart.

### Files changed
- `chart/kubestudio/templates/deployment.yaml` — swap `command:` for `args:`; splice `command`/`extraEnv` overrides
- `chart/kubestudio/templates/_helpers.tpl` — new `kubestudio.binaryPath` helper (reuses `kubestudio.binary`, produces `/usr/local/bin/<binary>`)
- `chart/kubestudio/values.yaml` — document new `command`, `args`, `extraEnv` values

Implements all three of the reporter's suggested fixes (absolute path, `args:` over `command:`, escape hatches).

## Test plan
Verified end-to-end on a local k3s cluster (`newdev`) against the chart built from this branch and an image built from the current `Dockerfile` (Debian + tini).

- [x] `helm lint chart/kubestudio` → passes
- [x] `helm template … --set command='{...}' --set args='{...}' --set 'extraEnv[0].name=…'` → all three overrides render as expected
- [x] `mode=standalone` install → pod `1/1 Running`, `0` restarts, `/proc/1/comm == tini`, `/proc/1/cmdline == tini -- /usr/local/bin/ks-server`, no `executable file not found in $PATH` events
- [x] `mode=ai-enabled` install pointed at a real Matrix (discoball staging) → connector runs under tini, connects, and registers as `matrix:<tenant>:<connector>:<instance>` (readiness fails due to a separate probe bug tracked as #46 — unrelated to #44)
- [x] Escape-hatch override renders correctly for `command`, `args`, `extraEnv`