### PR TITLE
fix(chart): emit KUBESTUDIO_MODE (name the binary reads)

### DIFF
--- a/chart/kubestudio/templates/deployment.yaml
+++ b/chart/kubestudio/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
               value: {{ .Values.kubestudio.port | quote }}
             - name: RUST_LOG
               value: {{ .Values.kubestudio.logLevel | quote }}
-            - name: KUBESTUDIO_PERMISSION_MODE
+            - name: KUBESTUDIO_MODE
               value: {{ if .Values.kubestudio.yolo }}"write"{{ else }}{{ .Values.kubestudio.permissionMode | quote }}{{ end }}
             {{- if .Values.kubestudio.yolo }}
             - name: KUBESTUDIO_YOLO


### PR DESCRIPTION
## Summary
Fixes #45.

The chart's `templates/deployment.yaml` was emitting the env var **`KUBESTUDIO_PERMISSION_MODE`**, but the compiled binary reads a differently-named env var: **`KUBESTUDIO_MODE`** (`crates/ks-ui/src/app/mod.rs:287` and `crates/ks-ui/src/bin/ks-connector.rs:1178`). Result: both `kubestudio.yolo` and `kubestudio.permissionMode` in `values.yaml` were silently no-ops — pods booted in the binary's default regardless of chart config, even though the cluster-admin RBAC binding was correctly created.

Single-line rename in the chart to align the emitted env-var name with the one the binary reads.

### Files changed
- `chart/kubestudio/templates/deployment.yaml` — one-line rename

## Test plan
Verified on a local k3s cluster (`newdev`) against a real Matrix (discoball staging).

- [x] `helm lint chart/kubestudio` → passes
- [x] `helm template … --set kubestudio.yolo=true` → renders `KUBESTUDIO_MODE=write` (was `KUBESTUDIO_PERMISSION_MODE=write`)
- [x] Standalone install with `kubestudio.yolo=true`: pod env carries `KUBESTUDIO_MODE=write`; `KUBESTUDIO_PERMISSION_MODE` no longer present
- [x] ai-enabled install pointed at discoball: connector startup log shows `Permission Mode: READ-WRITE (cluster-admin)` (previously fell back to code default because the emitted env var was silently ignored)
- [x] Matrix registration completes end-to-end