### PR TITLE
fix(chart): probe glob for connector socket, not hardcoded PID 1

### DIFF
--- a/chart/kubestudio/templates/deployment.yaml
+++ b/chart/kubestudio/templates/deployment.yaml
@@ -90,19 +90,24 @@ spec:
               containerPort: {{ .Values.kubestudio.port }}
               protocol: TCP
           {{- if eq .Values.mode "ai-enabled" }}
+          {{- /*
+            The connector writes its liveview socket at /tmp/ks-connector-<pid>.sock
+            (crates/ks-ui/src/ipc.rs). With tini as PID 1 the connector's PID varies,
+            so we glob for any matching socket rather than assuming a fixed PID.
+          */}}
           livenessProbe:
             exec:
-              command: ["test", "-S", "/tmp/ks-connector-1.sock"]
+              command: ["sh", "-c", "ls /tmp/ks-connector-*.sock >/dev/null 2>&1"]
             initialDelaySeconds: 5
             periodSeconds: 10
           readinessProbe:
             exec:
-              command: ["test", "-S", "/tmp/ks-connector-1.sock"]
+              command: ["sh", "-c", "ls /tmp/ks-connector-*.sock >/dev/null 2>&1"]
             initialDelaySeconds: 5
             periodSeconds: 10
           startupProbe:
             exec:
-              command: ["test", "-S", "/tmp/ks-connector-1.sock"]
+              command: ["sh", "-c", "ls /tmp/ks-connector-*.sock >/dev/null 2>&1"]
             failureThreshold: 30
             periodSeconds: 2
           {{- else }}


### PR DESCRIPTION
## Summary
Fixes #46.

In `mode: ai-enabled`, the chart's liveness / readiness / startup probes execed `test -S /tmp/ks-connector-1.sock`. But the connector writes its Dioxus liveview socket at `/tmp/ks-connector-{pid}.sock` (`crates/ks-ui/src/ipc.rs:29`), where `{pid}` is the connector process's PID. The Dockerfile keeps `tini` as PID 1, so the connector's PID is never 1 — meaning the probes always fail and kubelet restart-loops a healthy, Matrix-registered pod indefinitely.

Switch the probes to a shell glob against the actual socket path pattern:

```yaml
exec:
  command: ["sh", "-c", "ls /tmp/ks-connector-*.sock >/dev/null 2>&1"]
```

The Debian runtime image ships `/bin/sh`, so exec-form works without a wrapper. The command string is a chart-controlled literal with no `.Values` interpolation — no shell-injection surface. A short template comment above the probe block cites the source file to keep future maintainers pointed at the origin of the pattern.

### Files changed
- `chart/kubestudio/templates/deployment.yaml` — three probes swapped; template comment added

## Test plan
Verified on a local k3s cluster (`newdev`) against a real Matrix (discoball staging).

- [x] `helm lint chart/kubestudio` → passes
- [x] `helm template --set mode=ai-enabled … | grep startupProbe` → renders the shell-glob command
- [x] Isolated install in `mode=ai-enabled` pointed at discoball: pod `1/1 Running`, `0` restarts sustained, `.spec.containers[0].startupProbe.exec.command` on the running pod is exactly the shell-glob, connector registers with Matrix, no probe-failed events. *(Note: on this branch alone the connector still lands at PID 1 because `command:` is still hardcoded — the failure condition #46 actually describes only manifests once #44's fix is also on `main`. The glob is a strict superset of the old fixed-path check, so it can't regress the previously-working case, and by construction the socket's `{pid}.sock` will always match the glob.)*
- [x] Static reasoning: shell-glob semantics match any PID the connector picks; connector's own startup log emits the socket path it writes.

## Follow-up (optional, out of scope)
A cleaner durable fix would be to have the connector write a fixed-name symlink (e.g. `/tmp/ks-connector.sock -> ks-connector-<pid>.sock`) on startup, and switch the probe back to a plain `test -e`. Happy to open that as a separate issue if the team prefers.