### PR TITLE
fix(ci): one canonical multi-arch image publisher + working distroless image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,37 +25,9 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  docker:
-    name: Docker Image
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/metadata-action@v5
-        id: meta
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix=
-
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+  # Container image publishing lives in docker-multiarch.yml (native multi-arch,
+  # same `v*` tag trigger). Keeping it there avoids two workflows racing to
+  # overwrite the same tag with different manifests.
 
   build:
     name: Desktop (${{ matrix.name }})
@@ -351,7 +323,7 @@ jobs:
 
   release:
     name: Release
-    needs: [build, build-connector, docker]
+    needs: [build, build-connector]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -1,18 +1,25 @@
 # ============================================================
-# KubeStudio — multi-arch minimal container image
+# KubeStudio — multi-arch distroless container image
 # ============================================================
-# Uses gcr.io/distroless/cc-debian12 as runtime — ~25MB base with
-# libc + libssl + CA certs, no shell, no package manager.
+# Runtime base: gcr.io/distroless/cc-debian12 — glibc, libssl, ca-certs, no
+# shell, no package manager. Adds only what the app actually needs:
+#   * tini              — PID 1 init (signal fwd + zombie reap)
+#   * busybox-static    — sh/ls/test for exec probes in ai-enabled mode
+#                         (the chart's liveness/readiness probes for the
+#                         connector rely on `sh -c 'ls /tmp/…'`)
+#   * ks-server         — standalone web UI
+#   * ks-connector      — Matrix AI connector
 #
-# Usage:
-#   docker buildx build --platform linux/amd64,linux/arm64 \
-#     -t ghcr.io/strike48-public/kubestudio:latest \
-#     -f Dockerfile.scratch --push .
+# Binary selection is done via the Helm chart's `args:` field (the image sets
+# no hardcoded CMD-only entrypoint), so a single image serves both
+# `mode=standalone` (default `ks-server`) and `mode=ai-enabled` (`ks-connector`).
 
 # ----------------------------------------------------------
-# Stage 1: cargo-chef planner (runs on build host)
+# Stage 1: cargo-chef planner — computes a stable recipe hash of the
+# workspace's dependency graph, which stage 2 uses to cache-cook deps
+# independently of the source files.
 # ----------------------------------------------------------
-FROM --platform=$BUILDPLATFORM rust:1.88-bookworm AS chef
+FROM rust:1.88-bookworm AS chef
 RUN cargo install cargo-chef --locked
 WORKDIR /app
 
@@ -21,40 +28,60 @@ COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 # ----------------------------------------------------------
-# Stage 2: Builder (native per target arch via QEMU)
+# Stage 2: Builder — native per target arch. docker-multiarch.yml runs
+# this on ubuntu-latest (amd64) and ubuntu-24.04-arm (arm64) so both
+# arches build natively with no QEMU.
 # ----------------------------------------------------------
-FROM rust:1.88-bookworm AS builder
-
+FROM chef AS builder
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config libssl-dev protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
-RUN cargo install cargo-chef --locked
-
-WORKDIR /app
 COPY --from=planner /app/recipe.json recipe.json
-
-# Pre-cache dependencies
 RUN cargo chef cook --release --recipe-path recipe.json \
     --features server,connector --no-default-features -p ks-ui
 
-# Build actual binaries
 COPY . .
 RUN cargo build --release \
     --bin ks-server --bin ks-connector \
     --features server,connector --no-default-features -p ks-ui
 
 # ----------------------------------------------------------
-# Stage 3: Distroless — no shell, no pkg manager, ~25MB
+# Stage 3: Runtime helpers — tini + busybox + minimal passwd/group
+# for UID 999 (which the Helm chart hardcodes in securityContext).
+# We pull tini and busybox-static from Debian rather than downloading
+# GitHub releases, so builds stay reproducible against an APT snapshot.
+# ----------------------------------------------------------
+FROM debian:bookworm-slim AS layout
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    tini busybox-static \
+    && rm -rf /var/lib/apt/lists/*
+
+# Everything the distroless final stage needs is staged under /rootfs so
+# a single COPY --from=layout / / lands it in the right places.
+RUN mkdir -p /rootfs/usr/local/bin /rootfs/etc /rootfs/tmp \
+    && cp /usr/bin/tini /rootfs/usr/local/bin/tini \
+    && cp /bin/busybox /rootfs/usr/local/bin/busybox \
+    && ln -s busybox /rootfs/usr/local/bin/sh \
+    && ln -s busybox /rootfs/usr/local/bin/ls \
+    && ln -s busybox /rootfs/usr/local/bin/test \
+    && echo 'kubestudio:x:999:999::/tmp:/usr/local/bin/false' > /rootfs/etc/passwd \
+    && echo 'kubestudio:x:999:' > /rootfs/etc/group
+
+# ----------------------------------------------------------
+# Stage 4: Distroless runtime — ~25 MB base with glibc + libssl + CA certs.
+# No apt, no package manager, no libraries beyond what we pull in.
 # ----------------------------------------------------------
 FROM gcr.io/distroless/cc-debian12
 
-COPY --from=builder /app/target/release/ks-server /usr/local/bin/ks-server
-COPY --from=builder /app/target/release/ks-connector /usr/local/bin/ks-connector
+COPY --from=layout /rootfs/ /
+COPY --from=builder /app/target/release/ks-server     /usr/local/bin/ks-server
+COPY --from=builder /app/target/release/ks-connector  /usr/local/bin/ks-connector
 
-USER 999:999
-
+# /usr/local/bin/ is early on distroless's PATH — no need to override.
+USER 999
 ENV PORT=8080
 EXPOSE 8080
 
-ENTRYPOINT ["ks-server"]
+ENTRYPOINT ["tini", "--"]
+CMD ["ks-server"]

--- a/justfile
+++ b/justfile
@@ -1,6 +1,13 @@
-# ============ Docker (Multi-Arch Scratch) ============
+# ============ Docker (Multi-Arch Distroless) ============
+#
+# Canonical Dockerfile is `Dockerfile.scratch` (distroless/cc + tini + static
+# busybox). CI publishes multi-arch via .github/workflows/docker-multiarch.yml
+# on push to main and on `v*` tag.
+#
+# `Dockerfile` (Debian + tini) is retained as a developer-friendly local build
+# with a full shell for interactive debugging — not published by CI.
 
-# Build multi-arch scratch image locally (loads into docker)
+# Build the canonical distroless image locally (loads into docker)
 docker-build tag="latest":
     docker buildx build \
         --platform linux/amd64 \
@@ -8,7 +15,7 @@ docker-build tag="latest":
         -t ghcr.io/strike48-public/kubestudio:{{tag}} \
         -f Dockerfile.scratch .
 
-# Build and inspect Dockerfile.scratch (dry-run to see layers)
+# Build and inspect the canonical distroless image
 docker-package:
     @echo "=== Dockerfile.scratch ==="
     @cat Dockerfile.scratch


### PR DESCRIPTION
## Summary
Fixes #52.

Two things this PR does, one primary + one enabling:

### Primary — remove the duplicate publisher (root cause of #52)
`release.yml` and `docker-multiarch.yml` were both configured to push image tags like `:{version}`, `:{major}.{minor}`, `:{sha}` on a `v*` tag push. The multi-arch workflow published a proper multi-arch manifest first; the single-arch amd64-only push from `release.yml`'s `docker` job clobbered it ~2 min later, silently dropping the `linux/arm64` platform from every semver tag.

Fix: delete the `docker` job in `release.yml`. `docker-multiarch.yml` is now the single canonical publisher (native amd64 runner + native arm64 runner + `buildx imagetools create` merge — the way it was already meant to work).

### Enabling — make the distroless variant actually usable
`docker-multiarch.yml` builds from `Dockerfile.scratch` (distroless). The prior version of that file had three latent bugs that would silently regress every chart fix from the previous cycle:

- ENTRYPOINT hardcoded to `["ks-server"]` — `mode=ai-enabled` can't run `ks-connector`, defeating #44's mode-selectable design.
- No `tini` — pod runs as PID 1 with no init (loses signal fwd + zombie reap).
- No `/bin/sh` — the ai-enabled probes (`sh -c 'ls /tmp/ks-connector-*.sock …'`) fail to exec, kubelet restart-loops a healthy pod (regresses #46).

Rewrite (`Dockerfile.scratch`):
- `gcr.io/distroless/cc-debian12` runtime.
- COPY `tini` from a Debian layout stage — dynamically links to distroless's libc; ENTRYPOINT `["tini", "--"]` preserves the #44 PID-1 design.
- COPY `busybox-static` and symlink `sh`, `ls`, `test` under `/usr/local/bin` — restores what the ai-enabled probes need, ~1 MB static.
- COPY minimal `/etc/passwd` + `/etc/group` for UID/GID 999 (chart hardcodes `runAsUser: 999`).
- COPY both `ks-server` and `ks-connector` at `/usr/local/bin/` — chart's `args:` selects the binary at runtime.
- CMD `["ks-server"]` — sensible default; ai-enabled overrides via chart args.

### Files changed
- `.github/workflows/release.yml` — remove `docker` job + drop from `release` needs list.
- `Dockerfile.scratch` — rewrite (working distroless).
- `justfile` — point local build recipes at the canonical `Dockerfile.scratch`.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` on both workflow files — syntactically valid.
- [x] `docker buildx build --platform linux/amd64 -f Dockerfile.scratch .` — builds, image ~36 MB (Debian variant was ~58 MB).
- [x] `docker run --platform linux/amd64` smoke test: pod stays up, `/health` returns `OK`, PID 1 = tini, `sh` resolves via PATH.
- [x] `docker buildx build --platform linux/arm64 -f Dockerfile.scratch .` — builds natively on Apple Silicon.
- [x] Push arm64 image to zot, `helm install kubestudio-ds --set mode=ai-enabled … --set connector.strikeUrl=wss://discoball.strike48.engineering …` on newdev k3s (arm64):
  - Pod `1/1 Running`, `0` restarts.
  - `/proc/1/comm` == `tini`; `cmdline` == `tini -- /usr/local/bin/ks-connector` (#44 preserved).
  - Pod env: `KUBESTUDIO_MODE=write` (#45 preserved).
  - Socket at `/tmp/ks-connector-7.sock` (non-1 PID — tini is PID 1); shell-glob probe passes (#46 preserved).
  - Matrix registration: `matrix:use-non-c-discoball:kubestudio-distroless:kubestudio-distroless` on discoball.

## Downstream impact
- **Consumers pinned to `:0.2.1`** — no retroactive effect (already published).
- **Future tag pushes (`v0.2.2`, `v0.3.0`, …)** — receive genuinely multi-arch `:{version}` / `:{major}.{minor}`; arm64 K8s consumers stop being blocked at `:0.1.5`.
- **`:main` tag** — same publisher as before; no behavior change.
- **Strikehub** — unaffected. It downloads `ks-connector-<os>-<arch>` release assets from the `build-connector` matrix job in `release.yml`, which is untouched.
- **Desktop / connector release binaries** — unaffected. `release.yml`'s `build` and `build-connector` matrices still produce them.

## Rejected alternative
Making `Dockerfile` (Debian + tini) the canonical image is simpler but loses distroless's win: no shell / no package manager / no coreutils, ~36 MB vs ~58 MB. This PR keeps distroless as canonical while adding the minimum surface (static busybox + tini) needed for the current chart to work against it.