### PR TITLE
docs: fix GHCR org slug (strike48 → strike48-public)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/*"]
 version = "0.1.0"
 edition = "2024"
 license = "MPL-2.0"
-repository = "https://github.com/strike48/kubestudio"
+repository = "https://github.com/strike48-public/kubestudio"
 
 [workspace.dependencies]
 # Async runtime

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Pre-built images are published to GHCR on every release:
 docker run -p 8080:8080 \
   -v ~/.kube/config:/etc/kubestudio/kubeconfigs/default:ro \
   -e KUBECONFIG=/etc/kubestudio/kubeconfigs/default \
-  ghcr.io/strike48/kubestudio:latest
+  ghcr.io/strike48-public/kubestudio:latest
 ```
 
 Or build locally:


### PR DESCRIPTION
## Summary
- `README.md:108` — docker pull example used `ghcr.io/strike48/kubestudio:latest`, but the image is published at `ghcr.io/strike48-public/kubestudio:latest`. GHCR returns `denied` for the missing path (not `not found`), which is the error users hit.
- `Cargo.toml:9` — workspace `repository` URL pointed at the private `strike48/kubestudio` mirror; changed to the public canonical repo.

Every other reference (Helm chart values, `docker-multiarch.yml` publish workflow) already uses `strike48-public`, so this only aligns the docs + manifest with the release pipeline.

Fixes #55.

## Test plan
- [x] Anonymous GHCR probe: `ghcr.io/strike48-public/kubestudio:latest` → HTTP 200; `ghcr.io/strike48/kubestudio:latest` → 404.
- [x] Reviewer sanity-checks the two-line diff.