### PR TITLE
fix(deps): clear RUSTSEC-2026-0204 + track quick-xml DoS advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -25,4 +25,10 @@ ignore = [
 
     # Strike48 SDK still uses tonic 0.12 → rustls-pemfile (Linux target only)
     "RUSTSEC-2025-0134", # rustls-pemfile (unmaintained)
+
+    # wayland-scanner 0.31 pins quick-xml ^0.39 — build-time XML parser
+    # for bundled Wayland protocol files, not runtime user input. Linux
+    # desktop only; drops when wayland-scanner bumps quick-xml >=0.41.
+    "RUSTSEC-2026-0194", # quick-xml (quadratic runtime — DoS)
+    "RUSTSEC-2026-0195", # quick-xml (unbounded namespace alloc — DoS)
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -6202,9 +6202,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "stable_deref_trait"

--- a/deny.toml
+++ b/deny.toml
@@ -79,6 +79,30 @@ ignore = [
     # the [graph] targets list above ensures local `cargo deny` checks
     # this the same way CI does.
     "RUSTSEC-2025-0134", # rustls-pemfile (unmaintained — tonic 0.12)
+
+    # ---------------------------------------------------------------------
+    # quick-xml 0.39 — transitive via wayland-scanner 0.31.10 →
+    # wayland-client 0.31.14 → rfd 0.17.2 (file-dialog backend used by
+    # dioxus-desktop). wayland-scanner pins `quick-xml = "^0.39"`, and
+    # 0.31.10 is the latest published version — no compatible upgrade
+    # path exists until wayland-scanner relaxes that bound.
+    #
+    # Both advisories describe DoS vectors triggered when NsReader
+    # parses untrusted XML. wayland-scanner uses quick-xml at BUILD
+    # TIME only, to parse Wayland protocol XML files bundled in the
+    # wayland-client crate — never runtime, never attacker-controlled
+    # input. The reachable exposure is zero for this codebase.
+    #
+    # Linux desktop targets only; macOS/Windows do not pull the
+    # wayland chain.
+    #
+    # Removal trigger (any one of):
+    #   - wayland-scanner (or a fork) bumps quick-xml to >=0.41, or
+    #   - rfd swaps its Linux backend off wayland-client, or
+    #   - we replace rfd as the file-dialog crate.
+    # Upstream: https://github.com/Smithay/wayland-rs (quick-xml bump)
+    "RUSTSEC-2026-0194", # quick-xml (quadratic runtime — DoS)
+    "RUSTSEC-2026-0195", # quick-xml (unbounded namespace alloc — DoS)
 ]
 
 [licenses]

--- a/docs/dependency-tracking.md
+++ b/docs/dependency-tracking.md
@@ -28,8 +28,10 @@ below that no longer reproduce.
 | RUSTSEC-2026-0097 (`rand` 0.7 — remaining) | `rand` | **Upstream-blocked** (wry kuchikiki fork) |
 | RUSTSEC-2024-0436 | `paste` | **Upstream-blocked** (dioxus-desktop pulls `image` with default features → ravif → rav1e → paste) |
 | RUSTSEC-2025-0134 | `rustls-pemfile` | **Upstream-blocked** (Strike48 SDK still uses tonic 0.12) |
+| RUSTSEC-2026-0194 | `quick-xml` 0.39 (DoS) | **Upstream-blocked** (wayland-scanner pins ^0.39; build-time parser, not reachable) |
+| RUSTSEC-2026-0195 | `quick-xml` 0.39 (DoS) | **Upstream-blocked** (same chain as above) |
 
-7 advisories cleared by version bumps. 12 remain, all upstream-blocked
+7 advisories cleared by version bumps. 14 remain, all upstream-blocked
 on concrete external work tracked below.
 
 ## GTK3 binding chain (RUSTSEC-2024-0411..0420 less 0417, plus 0370, 0429)
@@ -88,6 +90,37 @@ features from this side without a `[patch.crates-io]` fork of
 The transitive `libfuzzer-sys 0.4.12` license (NCSA) is added to the
 allow-list in `deny.toml` — OSI-approved permissive license,
 comparable to MIT/BSD.
+
+## quick-xml 0.39 (RUSTSEC-2026-0194, RUSTSEC-2026-0195)
+
+Both advisories describe DoS vectors reachable when `NsReader` parses
+untrusted XML (quadratic runtime on duplicate-attribute check;
+unbounded namespace-declaration allocation). Fixed in `quick-xml >=0.41`.
+
+**Path:** `dioxus-desktop 0.7.9` → `rfd 0.17.2` → `wayland-client 0.31.14`
+→ `wayland-scanner 0.31.10` → `quick-xml 0.39.4`. Linux desktop targets
+only.
+
+**Why accepted:** `wayland-scanner 0.31.10` (the latest published
+version) pins `quick-xml = "^0.39"`. Cargo therefore refuses to select
+0.41 anywhere in the tree. More importantly, `wayland-scanner` uses
+`quick-xml` **at build time only** — to parse the bundled Wayland
+protocol XML files shipped inside the `wayland-client` crate. The
+advisories' threat model (attacker-controlled XML passed to an
+`NsReader` at runtime) is not reached; the parsed input is a set of
+fixed, trusted files that don't cross a trust boundary.
+
+**Removal trigger (any one of):**
+
+- `wayland-scanner` (or a maintained fork) bumps `quick-xml` to
+  `>=0.41`, or
+- `rfd` swaps its Linux backend off `wayland-client`, or
+- We replace `rfd` as the file-dialog crate.
+
+**Upstream status to watch:**
+
+- wayland-rs repo: <https://github.com/Smithay/wayland-rs>
+- quick-xml migration notes: <https://github.com/tafia/quick-xml/blob/master/Changelog.md>
 
 ## rustls-pemfile (RUSTSEC-2025-0134)
 


### PR DESCRIPTION
## Summary
Restores Security workflow green (both `Dependency Audit` and `License & Supply Chain` jobs) after three RUSTSEC advisories dropped between 2026-06-29 and 2026-07-06.

- **crossbeam-epoch** 0.9.18 → 0.9.20 — fixes **RUSTSEC-2026-0204** (invalid pointer deref in `fmt::Pointer` for `Atomic`/`Shared`). `Cargo.lock` only.
- **spin** 0.9.8 → 0.9.9 — clears the yanked-version warning.
- **quick-xml** RUSTSEC-2026-0194 (quadratic runtime, 7.5 high) + **RUSTSEC-2026-0195** (unbounded `NsReader` allocation → memory-exhaustion DoS, 7.5 high) — added tracked ignores to `deny.toml` and `.cargo/audit.toml`, with the same shape as the existing GTK3-chain entries (chain, exposure analysis, removal trigger). Docs updated in `docs/dependency-tracking.md`.

## Why quick-xml wasn't bumped
`wayland-scanner 0.31.10` (the latest published version) pins `quick-xml = "^0.39"`. Cargo refuses to select 0.41 anywhere in the tree — verified with `cargo update -p quick-xml --precise 0.41.0 --dry-run`.

Real-world exposure to both advisories is nil: `wayland-scanner` uses `quick-xml` **at build time only** to parse the Wayland protocol XML files bundled inside `wayland-client`. The attacker-controlled-XML → `NsReader` threat model does not apply. Linux desktop targets only.

**Removal trigger (any one):**
- `wayland-scanner` (or a maintained fork) bumps `quick-xml` to `>=0.41`, or
- `rfd` swaps its Linux backend off `wayland-client`, or
- we replace `rfd` as the file-dialog crate.

## Fixes
Closes #57.

## Test plan
Local CI-parity verification (all green):

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --features desktop -- -D warnings`
- [x] `cargo test --workspace --features desktop`
- [x] `cargo build --bin ks-server --features server --no-default-features -p ks-ui`
- [x] `cargo audit` → 0 errors (3 pre-existing allowed warnings)
- [x] `cargo deny check` → advisories/bans/licenses/sources all `ok`
- [ ] CI Security workflow green on this PR
- [ ] Reviewer sanity-checks the ignore rationale and removal triggers

## Follow-up (out of scope)
`RUSTSEC-2025-0134` (rustls-pemfile) in the allowlist now fires `advisory-not-detected` on both macOS and Linux targets — the advisory appears to have been withdrawn or superseded upstream. Worth pruning in a separate housekeeping PR.