### PR TITLE
fix(ui): dark-mode default + single-click theme toggle (#54)

### DIFF
--- a/crates/ks-ui/src/app/mod.rs
+++ b/crates/ks-ui/src/app/mod.rs
@@ -163,16 +163,15 @@ pub fn App() -> Element {
     // Keybindings modal state
     let mut keybindings_modal_open = use_signal(|| false);
 
-    // Theme state — data-theme attribute toggle (Strike48 design system)
+    // Theme state — data-theme attribute toggle (Strike48 design system).
+    // Default to dark; the mount effect below applies the stored preference
+    // (or dark) to the DOM and syncs the signal in a single step so the
+    // toggle button never disagrees with the visible theme.
     let mut is_dark = use_signal(|| true);
 
-    // Sync is_dark with the actual DOM state on mount
     use_effect(move || {
         spawn(async move {
-            if let Ok(val) = document::eval(
-                "return document.documentElement.getAttribute('data-theme') === 'strike48'",
-            )
-            .await
+            if let Ok(val) = document::eval(crate::theme::theme_init_eval()).await
                 && let Some(dark) = val.as_bool()
             {
                 is_dark.set(dark);
@@ -1686,7 +1685,6 @@ pub fn App() -> Element {
     // NOTE: This section is too large to include inline in the module documentation
     // but cannot be extracted due to signal capture requirements
     rsx! {
-        script { dangerous_inner_html: crate::theme::theme_init_script() }
         style { {crate::theme::theme_css()} }
         style { {include_str!("../styles/main.css")} }
         // Handle horizontal scrolling with arrow keys (vertical works naturally)

--- a/crates/ks-ui/src/theme.rs
+++ b/crates/ks-ui/src/theme.rs
@@ -367,20 +367,16 @@ pub fn theme_css() -> &'static str {
     "#
 }
 
-/// Small JS snippet that runs once on page load to apply the saved
-/// theme (or the OS default) before the first paint.
-pub fn theme_init_script() -> &'static str {
+/// JS expression that resolves the effective theme (defaulting to dark),
+/// applies the corresponding `data-theme` attribute, and returns `true`
+/// when dark is active. Executed via `document::eval` on mount so the
+/// initial signal and DOM stay aligned; ignores OS `prefers-color-scheme`
+/// because Strike48 is dark-first by design.
+pub fn theme_init_eval() -> &'static str {
     r#"
-    (function() {
-        var stored = localStorage.getItem('theme');
-        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        var useDark = stored ? stored === 'dark' : prefersDark;
-
-        if (useDark) {
-            document.documentElement.setAttribute('data-theme', 'strike48');
-        } else {
-            document.documentElement.setAttribute('data-theme', 'strike48-light');
-        }
-    })();
+    var stored = localStorage.getItem('theme');
+    var useDark = stored ? stored === 'dark' : true;
+    document.documentElement.setAttribute('data-theme', useDark ? 'strike48' : 'strike48-light');
+    return useDark;
     "#
 }


### PR DESCRIPTION
Closes #54.

## Summary
- **Root cause:** theme init lived in an `rsx! { script { dangerous_inner_html: … } }` tag. Scripts injected via `innerHTML` don't execute (HTML5 spec), so the DOM loaded with no `data-theme` attribute. CSS `:root` painted dark, but the mount effect read `getAttribute('data-theme') === 'strike48'` as `false` and set `is_dark = false` — signal disagreed with the visible theme, so the first click just "fixed" the DOM (no visual change) and only the second click actually toggled.
- The (non-executing) init also honoured `prefers-color-scheme`, which is why the StrikeHub webview started in light mode against Strike48's dark-first design.
- **Fix:** move init to `document::eval` inside the mount effect (which does execute), drop the OS-preference check so we default to dark, and apply the DOM attribute + sync the signal in one step so they can't disagree.

## Test plan
- [x] Standalone (`cargo run`) — launches dark, single click → light, single click → dark.
- [x] App mode (`KUBESTUDIO_MODE=write cargo run`) — same, no regression.
- [x] StrikeHub-hosted (`~/code/strike48-public/strikehub` picking up sibling `target/debug/ks-connector`) — now launches dark (previously light) and single-click toggles.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --features desktop -- -D warnings`
- [x] `cargo test --workspace --features desktop` (71 pass, 0 fail)
- [x] `cargo build --bin ks-server --features server --no-default-features -p ks-ui`
- [x] No `Cargo.toml` / `Cargo.lock` changes → audit/deny unchanged vs main.

## Notes for reviewers
- Users with a stale `theme=light` in `localStorage` from previous runs will keep light on next launch (respected preference) — that's intended. Fresh installs get dark.