### PR TITLE
security(ci): add PII-name scanner + CI check (port of pick#336)

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# commit-msg hook - Block commit messages that mention customer PII.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCANNER="$REPO_ROOT/scripts/check-pii.sh"
+MSG_FILE="$1"
+
+if [[ ! -x "$SCANNER" ]]; then
+    exit 0
+fi
+
+if ! "$SCANNER" "$MSG_FILE" >&2; then
+    echo "" >&2
+    echo "Commit blocked: customer names (PII) found in commit message." >&2
+    exit 1
+fi
+
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -35,4 +35,34 @@ else
     echo "  WARNING: cargo-deny/cargo-audit not installed, skipping. Install with: cargo install cargo-deny"
 fi
 
+# 6. PII scan - block commits that introduce customer/tenant names.
+# Scans only the added lines in staged changes. The scanner itself and its
+# workflow are excluded because they legitimately reference the banned names
+# as pattern definitions.
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCANNER="$REPO_ROOT/scripts/check-pii.sh"
+
+if [[ ! -x "$SCANNER" ]]; then
+    echo "  WARNING: $SCANNER not found or not executable, skipping PII check" >&2
+else
+    echo "  Checking for customer names (PII)..."
+    added_lines="$(
+        git diff --cached -- . \
+            ':!scripts/check-pii.sh' \
+            ':!.github/workflows/pii-check.yml' \
+            ':!.githooks/pre-commit' \
+            ':!.githooks/commit-msg' \
+        | grep -E '^\+[^+]' || true
+    )"
+
+    if [[ -n "$added_lines" ]]; then
+        if ! printf '%s\n' "$added_lines" | "$SCANNER" >&2; then
+            echo "" >&2
+            echo "Commit blocked: customer names (PII) found in staged changes." >&2
+            echo "Remove the customer names above and retry, or bypass with --no-verify (not recommended)." >&2
+            exit 1
+        fi
+    fi
+fi
+
 echo "All pre-commit checks passed!"

--- a/.github/workflows/pii-check.yml
+++ b/.github/workflows/pii-check.yml
@@ -1,0 +1,69 @@
+name: PII Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-pii:
+    name: Scan for customer names
+    runs-on: ubuntu-latest
+    # The banned-name list is injected from a repository secret so the customer
+    # names never live in this public repo. Configure it under Settings ->
+    # Secrets and variables -> Actions -> PII_NAMES (newline- or comma-separated).
+    env:
+      PII_NAMES: ${{ secrets.PII_NAMES }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure scanner is executable
+        run: chmod +x scripts/check-pii.sh
+
+      - name: Verify PII name list is configured
+        run: |
+          if [[ -z "${PII_NAMES:-}" ]]; then
+            echo "::error::PII_NAMES secret is not set - the scanner cannot run."
+            echo "Add it under Settings -> Secrets and variables -> Actions."
+            exit 1
+          fi
+
+      - name: Check PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "Scanning PR title..."
+          printf '%s\n' "$PR_TITLE" | scripts/check-pii.sh
+
+      - name: Check PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          echo "Scanning PR body..."
+          printf '%s\n' "${PR_BODY:-<empty>}" | scripts/check-pii.sh
+
+      - name: Check commit messages
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          echo "Scanning commit messages between $BASE_SHA..$HEAD_SHA"
+          git log --format='%H%n%s%n%b%n---' "$BASE_SHA..$HEAD_SHA" | scripts/check-pii.sh
+
+      - name: Check changed file contents
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          echo "Scanning diff for added lines between $BASE_SHA..$HEAD_SHA"
+          # Only scan added lines (lines starting with '+' but not '+++') to avoid
+          # tripping on unchanged historical content or on removal of bad content.
+          git diff "$BASE_SHA..$HEAD_SHA" -- . ':!scripts/check-pii.sh' ':!.github/workflows/pii-check.yml' \
+            | grep -E '^\+[^+]' \
+            | scripts/check-pii.sh

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ Thumbs.db
 # Local config
 .env
 .env.local
+
+# PII scanner: the real banned-name list lives here, never committed.
+# Seed it from .pii-names.local.example. See scripts/check-pii.sh.
+.pii-names.local

--- a/.pii-names.local.example
+++ b/.pii-names.local.example
@@ -1,0 +1,14 @@
+# PII name list for scripts/check-pii.sh (LOCAL - do not commit the real one).
+#
+# Copy this file to `.pii-names.local` and replace the placeholders with the
+# actual customer/tenant names that must never appear in public artifacts.
+# `.pii-names.local` is gitignored so the real names never enter the repo.
+#
+# Format: one name per line. Blank lines and '#' comments are ignored.
+# Matching is case-insensitive and word-boundary anchored.
+#
+# In CI, the list is supplied instead via the $PII_NAMES secret/variable
+# (newline- or comma-separated) - see .github/workflows/pii-check.yml.
+
+example-customer-one
+example-customer-two

--- a/scripts/check-pii.sh
+++ b/scripts/check-pii.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# check-pii.sh - Scan text for customer names that must never appear in public artifacts.
+#
+# Usage:
+#   scripts/check-pii.sh [file ...]           # Scan one or more files
+#   echo "text" | scripts/check-pii.sh        # Scan stdin
+#   scripts/check-pii.sh --text "some text"   # Scan inline text
+#
+# Exit codes:
+#   0 - No PII found
+#   1 - PII found (one or more customer names detected)
+#   2 - Usage or configuration error (no name list available)
+#
+# The banned-name list is loaded at runtime from OUTSIDE this repository so the
+# customer names themselves never live in a public artifact. Sources, in order:
+#
+#   1. $PII_NAMES       - newline- or comma-separated names (used by CI, fed
+#                         from a repository secret/variable).
+#   2. $PII_NAMES_FILE  - path to a file with one name per line.
+#   3. .pii-names.local - a gitignored file at the repo root (local dev default).
+#
+# Lines beginning with '#' and blank lines in the file/variable are ignored.
+# If no source yields at least one name, the scanner FAILS LOUD (exit 2) rather
+# than silently passing - a scanner with an empty list protects nothing.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly REPO_ROOT
+readonly LOCAL_NAMES_FILE="${REPO_ROOT}/.pii-names.local"
+
+# Populate PII_NAMES from the first available source. Returns non-zero if none
+# of the sources provided any names.
+load_names() {
+    local raw=""
+
+    if [[ -n "${PII_NAMES:-}" ]]; then
+        raw="$PII_NAMES"
+    elif [[ -n "${PII_NAMES_FILE:-}" && -f "${PII_NAMES_FILE}" ]]; then
+        raw="$(cat "${PII_NAMES_FILE}")"
+    elif [[ -f "${LOCAL_NAMES_FILE}" ]]; then
+        raw="$(cat "${LOCAL_NAMES_FILE}")"
+    else
+        return 1
+    fi
+
+    # Split on newlines and commas; trim whitespace; drop blanks and comments.
+    NAMES=()
+    local line name
+    while IFS= read -r line; do
+        line="${line//,/$'\n'}"
+        while IFS= read -r name; do
+            name="${name#"${name%%[![:space:]]*}"}"  # ltrim
+            name="${name%"${name##*[![:space:]]}"}"  # rtrim
+            [[ -z "$name" || "$name" == \#* ]] && continue
+            NAMES+=("$name")
+        done <<< "$line"
+    done <<< "$raw"
+
+    [[ ${#NAMES[@]} -gt 0 ]]
+}
+
+# Build a single case-insensitive regex: \b(name1|name2|...)\b
+# Word boundaries prevent false positives on substrings.
+build_pattern() {
+    local pattern="" sep=""
+    for name in "${NAMES[@]}"; do
+        pattern+="${sep}${name}"
+        sep="|"
+    done
+    printf '\\b(%s)\\b' "$pattern"
+}
+
+# Scan stdin or arguments, print matches with file:line prefix, return status.
+scan() {
+    local source_label="$1"
+    local input="$2"
+    # -E extended regex, -i case-insensitive, -n line numbers, -H label prefix
+    if echo "$input" | grep -EHin --label="$source_label" --color=never -- "$PATTERN"; then
+        return 1
+    fi
+    return 0
+}
+
+main() {
+    if ! load_names; then
+        echo "ERROR: no PII name list available." >&2
+        echo "Provide names via \$PII_NAMES (CI secret), \$PII_NAMES_FILE, or ${LOCAL_NAMES_FILE}." >&2
+        echo "See scripts/check-pii.sh header for the format." >&2
+        exit 2
+    fi
+
+    PATTERN="$(build_pattern)"
+
+    local found=0
+
+    if [[ $# -eq 0 ]]; then
+        # stdin mode. Empty input is valid (nothing to scan = no PII).
+        local input
+        input="$(cat)"
+        if [[ -n "$input" ]]; then
+            scan "stdin" "$input" || found=1
+        fi
+    elif [[ "$1" == "--text" ]]; then
+        if [[ $# -lt 2 ]]; then
+            echo "Error: --text requires an argument" >&2
+            exit 2
+        fi
+        scan "text" "$2" || found=1
+    else
+        # File mode
+        for file in "$@"; do
+            if [[ ! -f "$file" ]]; then
+                echo "Warning: $file is not a regular file, skipping" >&2
+                continue
+            fi
+            if grep -EHin --color=never -- "$PATTERN" "$file"; then
+                found=1
+            fi
+        done
+    fi
+
+    if [[ $found -eq 1 ]]; then
+        echo "" >&2
+        echo "ERROR: Customer names (PII) detected in the content above." >&2
+        # Do NOT echo the name list here - this output reaches public CI logs.
+        echo "Replace with neutral placeholders like '<tenant-id>' or 'customer tenant'." >&2
+        exit 1
+    fi
+
+    exit 0
+}
+
+main "$@"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -6,7 +6,16 @@ HOOKS_DIR="$REPO_ROOT/.githooks"
 
 echo "Installing git hooks from $HOOKS_DIR..."
 git config core.hooksPath "$HOOKS_DIR"
+chmod +x "$HOOKS_DIR"/* "$REPO_ROOT/scripts/check-pii.sh"
 echo "Git hooks installed successfully."
+
+# Seed the local (gitignored) PII name list from the example if it's missing,
+# so the PII hooks have a list to scan against. The scanner fails loud without
+# one; edit .pii-names.local to add the real customer/tenant names.
+if [[ ! -f "$REPO_ROOT/.pii-names.local" && -f "$REPO_ROOT/.pii-names.local.example" ]]; then
+    cp "$REPO_ROOT/.pii-names.local.example" "$REPO_ROOT/.pii-names.local"
+    echo "Created .pii-names.local from the example - edit it to add the real names."
+fi
 
 # Check for required tools
 if ! command -v gitleaks &> /dev/null; then


### PR DESCRIPTION
## Summary
- Ports the hardened PII-name scanner from Strike48-public/pick #336 to prevent customer/tenant names appearing in this public repo.
- Banned-name list loads at runtime from `$PII_NAMES` (CI secret) or gitignored `.pii-names.local`; never hardcoded. Fails loud (exit 2) if unconfigured; never echoes names into CI logs.
- Adds pre-commit + commit-msg hooks and a `pii-check` GitHub Action (alongside existing workflows, none modified).

## Operator action after merge
Set a `PII_NAMES` secret (org-level recommended), newline- or comma-separated, or the PII Check job fails by design.

## Test plan
- [x] shellcheck clean; detects via `$PII_NAMES`; clean input passes; no list -> exit 2
- [x] No customer names hardcoded (grep verified); `.pii-names.local` gitignored; existing workflows untouched